### PR TITLE
BUG: participant ID and recover responses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,6 @@ services:
     image: redislabs/rejson
     ports:
       - '6379:6379'
+# To get bash on one of these machines:
+# docker exec -it <containerIdOrName> bash
+

--- a/frontend/frontend/private.py
+++ b/frontend/frontend/private.py
@@ -12,7 +12,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.status import HTTP_401_UNAUTHORIZED
 
-from .public import _ensure_initialized, app
+from .public import _ensure_initialized, app, _write
 from .utils import ServerException
 
 security = HTTPBasic()
@@ -99,6 +99,7 @@ async def process_form(
     exp_config.update(config)
     exp_config["n"] = len(exp_config["targets"])
     rj.jsonset("exp_config", root, exp_config)
+    _write(exp_config, "exp_config.json")
     return {
         "success": True,
         "documentation": [

--- a/frontend/templates/query_page.html
+++ b/frontend/templates/query_page.html
@@ -68,7 +68,7 @@
           {{ debrief | safe }}
       </div>
       <div class="modal-body">
-          Participant ID: {{ puid }}
+          Participant ID: <span id="puid">{{ puid }}</span>
       </div>
     </div>
   </div>
@@ -81,6 +81,7 @@ head = -1;
 left = -1;
 right = -1;
 puid = $("#puid").html();
+console.log(puid);
 targets = {{ targets | safe }};
 max_responses = {{ max_responses }};
 num_responses = 0;


### PR DESCRIPTION
**What does this PR implement?**
* Fixes participant ID on the HTML query page; before it was always `-1`.
* Writes responses to disk so the data can always be recovered.