### PR TITLE
MAINT: propogate errors on file upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,6 @@ login:
 	docker run -i -t salmon_frontend /bin/bash
 
 watch:
+	# for debugging on ec2, `sudo make watch`
 	docker-compose logs -f
+

--- a/tests/data/bad_exp.yaml
+++ b/tests/data/bad_exp.yaml
@@ -1,0 +1,3 @@
+targets:
+  -	foo
+  -	bar


### PR DESCRIPTION
**What does this PR implement?**
It propagates errors on encountered during file upload. This is provides the experimentalists with more context than "500: internal service error". For example, for the error behind #12 it shows this text on file upload:

``` 
Error!


Summary:

<class 'yaml.scanner.ScannerError'> while scanning for the next token
found character '\t' that cannot start any token
  in "<byte string>", line 2, column 4:
      -	Above
       ^

Full traceback:

  File "/opt/conda/bin/uvicorn", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
...
```

**Reference issues/PRs**
This PR will close #12.