### PR TITLE
ENH: show server side metrics on dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ creds.yaml
 __MACOSX
 dask-worker-space
 salmon/frontend/dump*rdb
+salmon/frontend/logs/*.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ FORCE: ;
 
 loop: FORCE
 	rm -f salmon/frontend/dump*.rdb
+	rm -f salmon/frontend/logs/*.log
 	docker-compose stop
 	docker-compose rm -f
 	docker-compose build

--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 15s
+
+    static_configs:
+      - targets: ['server:8421']
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,24 @@ services:
     sysctls:  # https://github.com/docker-library/redis/issues/191
       - net.core.somaxconn=65535
       - net.core.somaxconn=511
+    expose:
+      - 6379
     volumes:
       - type: bind
         source: ./salmon/frontend
         target: /data
     # also https://github.com/boot2docker/boot2docker/issues/1083#issuecomment-151380687
+
+  redismonitor:
+    build: redismonitor
+    ports:
+      - "7381:7389"
+    volumes:
+      - type: bind
+        source: ./salmon/frontend
+        target: /salmon
+    logging:
+      driver: none
 
   prom:
     image: prom/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "7381:7389"
     volumes:
       - type: bind
-        source: ./salmon/frontend
+        source: ./salmon/frontend/logs
         target: /salmon
     logging:
       driver: none

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,14 @@ services:
 
   prom:
     image: prom/prometheus
-    ports:
-      - "9090:9090"
+    expose:
+      - 9090
     volumes:
       - ./config:/etc/prometheus
-        # granfna:
-        #   image: grafana/grafana
-        #   ports:
-        #     - "3000:3000"
+        #  granfna:
+        #    image: grafana/grafana
+        #    ports:
+        #      - "3000:3000"
 
 # To get bash on one of these machines:
 # docker exec -it <containerIdOrName> bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - SALMON_NO_AUTH
     ports:
       - "8421:8421"
+    expose:
+      - 8421
     volumes:
       - type: bind
         source: .
@@ -23,6 +25,17 @@ services:
         source: ./salmon/frontend
         target: /data
     # also https://github.com/boot2docker/boot2docker/issues/1083#issuecomment-151380687
+
+  prom:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config:/etc/prometheus
+        # granfna:
+        #   image: grafana/grafana
+        #   ports:
+        #     - "3000:3000"
 
 # To get bash on one of these machines:
 # docker exec -it <containerIdOrName> bash

--- a/redismonitor/Dockerfile
+++ b/redismonitor/Dockerfile
@@ -1,0 +1,9 @@
+FROM redislabs/rejson
+
+# Run https://github.com/junegunn/redis-stat
+RUN apt update && apt install -y wget
+RUN apt-get install -y ruby-full
+RUN apt-get install -y build-essential
+RUN gem install redis-stat
+
+CMD redis-stat redis:6379 --csv=/salmon/logs/redis.csv 5 --server=7389

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -388,6 +388,16 @@ async def get_dashboard(request: Request, authorized: bool = Depends(_authorize)
         "network_latency": network_latency,
     }
     plots = {k: json.dumps(json_item(v)) for k, v in plots.items()}
+    endpoint_timing = await plotting.get_endpoint_time_plots()
+    plots["endpoint_timings"] = {k: json.dumps(json_item(v)) for k, v in endpoint_timing.items()}
+
+    endpoints = list(reversed(sorted(endpoint_timing.keys())))
+    if "/query" in endpoints:
+        i = endpoints.index("/query")
+        endpoints[0], endpoints[i] = endpoints[i], endpoints[0]
+    if "/answer" in endpoints:
+        i = endpoints.index("/answer")
+        endpoints[1], endpoints[i] = endpoints[i], endpoints[1]
     return templates.TemplateResponse(
         "dashboard.html",
         {
@@ -398,6 +408,7 @@ async def get_dashboard(request: Request, authorized: bool = Depends(_authorize)
             "num_responses": len(responses),
             "num_participants": df.puid.nunique(),
             "filenames": [_get_filename(html) for html in targets],
+            "endpoints": endpoints,
             **plots,
         },
     )

--- a/salmon/utils.py
+++ b/salmon/utils.py
@@ -1,19 +1,52 @@
+import asyncio
 import logging
+import logging.handlers
+from logging.handlers import QueueHandler
+from logging import LogRecord
 from pathlib import Path
 
+# Python 3.7 and newer, fast reentrant implementation
+# without task tracking (not needed for that when logging)
+from queue import SimpleQueue as Queue
+from typing import List
 
-def get_logger(name):
+
+def get_logger(name, level=logging.INFO):
     # Config from https://docs.python-guide.org/writing/logging/ and
     # https://docs.python-guide.org/writing/logging/
     logger = logging.getLogger(name)
     formatter = logging.Formatter(
-        "%(asctime)s %(levelname)s from %(name)s: %(message)s"
+        "%(asctime)s %(name)s %(levelname)s: %(message)s"
     )
 
-    handler2 = logging.StreamHandler()
-    handler2.setFormatter(formatter)
-    logger.addHandler(handler2)
+    ph = logging.StreamHandler()
+    ph.setFormatter(formatter)
+    ph.setLevel(level)
 
-    logger.setLevel(logging.INFO)
+    DIR = Path(__file__).absolute().parent
+    out = DIR / "frontend" / "logs" / f"{name}.log"
 
+    fh = logging.FileHandler(str(out))
+    fh.setLevel(level)
+    fh.setFormatter(formatter)
+
+    logger = background_logger(logger, fh, ph)
+    return logger
+
+
+def background_logger(logger, *handlers):
+    """Move log handlers to a separate thread.
+
+    Replace handlers on the root logger with a LocalQueueHandler,
+    and start a logging.QueueListener holding the original
+    handlers.
+
+    Adapted https://www.zopatista.com/python/2019/05/11/asyncio-logging/
+    """
+    queue = Queue()
+    async_handler = QueueHandler(queue)
+    logger.addHandler(async_handler)
+
+    listener = logging.handlers.QueueListener(queue, *handlers, respect_handler_level=True)
+    listener.start()
     return logger

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -91,6 +91,12 @@
           {% endfor %}
         </div>
     </div>
+    <div class="row justify-content-center">
+        <p>
+        <a href="/" onclick="javascript:event.target.port=7381">
+            Redis live monitoring</a>.
+        </p>
+    </div>
     <br><br>
     <div class="row justify-content-center">
       <h3>Client-side timing</h3>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -36,7 +36,15 @@
 <div class="container">
   <div class="outline justify-content-center">
     <div class="row justify-content-center">
-      <h2>Basic information</h2>
+      <div id="activity-plot"></div>
+      <script>
+      plot = JSON.parse({{ activity | tojson }});
+      Bokeh.embed.embed_item(plot, "activity-plot");
+      </script>
+    </div>
+    <br>
+    <div class="row justify-content-center">
+      <h3>Basic information</h3>
     </div>
     <div class="row justify-content-center">
       <ul>
@@ -46,28 +54,48 @@
         <li><a href="/">Query page</a></li>
         <li><a href="/responses">Responses</a></li>
         <li><a href="/download">Download experiment</a></li>
-      </ul>
-    </div>
-    <div class="row justify-content-center">
-      <h4>Debug information</h4>
-    </div>
-    <div class="row justify-content-center">
-      <ul>
         <li><a href="/docs">API Documentation</a></li>
         <li><a href="/logs">Logs</a></li>
-        <li><a href="/metrics">Various server metrics</a></li>
       </ul>
     </div>
     <div class="row justify-content-center">
-      <h2>Plots</h2>
     </div>
     <div class="row justify-content-center">
-      <div id="activity-plot"></div>
-      <script>
-      plot = JSON.parse({{ activity | tojson }});
-      Bokeh.embed.embed_item(plot, "activity-plot");
-      </script>
+      <h3>Server-side timing</h3>
     </div>
+    <br>
+    <div class="row justify-content-center">
+      <ul class="nav nav-tabs" id="myTab" role="tablist">
+        {% for endpoint in endpoints %}
+          <li class="nav-item">
+              <a class="nav-link {% if loop.first %}active{% endif %}" id="{{endpoint}}-tab" data-toggle="tab" href="#{{endpoint}}" role="tab" aria-controls="{{endpoint}}" aria-selected={% if loop.first %}"true"{% else %}"false"{% endif %}>
+              {{endpoint}}
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div class="row justify-content-center">
+        <div class="tab-content" id="myTabContent">
+          {% for endpoint in endpoints %}
+          <div class="tab-pane fade {% if loop.first %}show active{% endif %}"
+                id="{{ endpoint }}"
+                role="tabpanel"
+                aria-labelledby="{{endpoint}}-tab"
+            >
+              <script>
+              plot = JSON.parse({{ endpoint_timings[endpoint] | tojson }});
+              Bokeh.embed.embed_item(plot, "{{ endpoint }}");
+              </script>
+          </div>
+          {% endfor %}
+        </div>
+    </div>
+    <br><br>
+    <div class="row justify-content-center">
+      <h3>Client-side timing</h3>
+    </div>
+    <br>
     <div class="row justify-content-center">
       <span id="responses"></span>
       <span id="network-latency"></span>
@@ -79,7 +107,9 @@
       </script>
     </div>
     <div class="row justify-content-center">
-      <h2>Targets</h2>
+      <div class="row justify-content-center">
+        <h2>Targets</h2>
+      </div>
     </div>
     <div class="row justify-content-center markdown-body">
       <p>

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -217,5 +217,4 @@ def test_logs(server):
     assert r.status_code == 200
     logs = r.json()
     query_logs = logs["salmon.frontend.public.log"]
-    assert len(query_logs) == 10
-    assert all(puid in log for log in query_logs)
+    assert sum(puid in log for log in query_logs) == 10

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,11 +53,11 @@ class Server:
 @pytest.fixture()
 def server():
     # Make-pretend the logs have just been re-loaded...
-    base = Path(__file__).absolute().parent.parent
-    logs = base / "salmon" / "frontend" / "logs"
-    for log in logs.glob("*.log"):
-        log.unlink()
-        log.touch()
+    #  base = Path(__file__).absolute().parent.parent
+    #  logs = base / "salmon" / "frontend" / "logs"
+    #  for log in logs.glob("*.log"):
+        #  log.unlink()
+        #  log.touch()
     server = Server("http://127.0.0.1:8421")
     server.get("/reset?force=1", auth=server.auth())
     yield server

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,12 +52,6 @@ class Server:
 
 @pytest.fixture()
 def server():
-    # Make-pretend the logs have just been re-loaded...
-    #  base = Path(__file__).absolute().parent.parent
-    #  logs = base / "salmon" / "frontend" / "logs"
-    #  for log in logs.glob("*.log"):
-        #  log.unlink()
-        #  log.touch()
     server = Server("http://127.0.0.1:8421")
     server.get("/reset?force=1", auth=server.auth())
     yield server

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,6 +52,12 @@ class Server:
 
 @pytest.fixture()
 def server():
+    # Make-pretend the logs have just been re-loaded...
+    base = Path(__file__).absolute().parent.parent
+    logs = base / "salmon" / "frontend" / "logs"
+    for log in logs.glob("*.log"):
+        log.unlink()
+        log.touch()
     server = Server("http://127.0.0.1:8421")
     server.get("/reset?force=1", auth=server.auth())
     yield server


### PR DESCRIPTION
**What does this PR implement?**
This PR does the following:

- [x] Adds visualization of server side processing time on dashboard.
- [x] Visualizes Redis performance on dashboard (one of the tools from [this blog post][2]).
- [x] Fixes and tests for logging, and also improves performance (writing in background thread)

**Reference issues/PRs**
This PR will close #21. As mentioned in https://github.com/stsievert/salmon/issues/21#issuecomment-622179488, there are only a couple containers to get logs from.

[2]:https://blog.serverdensity.com/monitor-redis/