### PR TITLE
MAINT: download responses as CSV files

### DIFF
--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -345,7 +345,7 @@ def reset(
 
 
 @app.get("/responses", tags=["private"])
-async def get_responses(authorized: bool = Depends(_authorize)) -> Dict[str, Any]:
+async def get_responses(authorized: bool = Depends(_authorize), json: Optional[bool] = True) -> Dict[str, Any]:
     """
     Get the recorded responses from the current experiments. This includes
     the following columns:
@@ -371,6 +371,10 @@ async def get_responses(authorized: bool = Depends(_authorize)) -> Dict[str, Any
     start = rj.jsonget("start_time")
     responses = await _get_responses()
     json_responses = await _format_responses(responses, targets, start)
+    if json:
+        return JSONResponse(
+            json_responses, headers={"Content-Disposition": 'attachment; filename="responses.json"'}
+        )
     with StringIO() as f:
         df = pd.DataFrame(json_responses)
         df.to_csv(f, index=False)

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -358,10 +358,12 @@ async def get_responses(authorized: bool = Depends(_authorize)) -> Dict[str, Any
     * `response_time`: the time spent between the providing the query and
       receiving the answer.
 
+    There may be additional columns.
+
     Returns
     -------
-    The list of responses as a JSON file. This file can be read by
-    Panda's `read_json` function.
+    The list of responses as a CSV file. This file can be read by
+    Panda's `read_csv` function.
 
     """
     exp_config = await _ensure_initialized()

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -52,8 +52,9 @@
         <li>Number of responses: {{num_responses }}</li>
         <li>Number of participants: {{ num_participants }}</li>
         <li><a href="/">Query page</a></li>
-        <li>
-          <a href="/responses">Responses</a>&nbsp;
+        <li>Responses:
+          <a href="/responses?json=0">CSV</a>,&nbsp;
+          <a href="/responses?json=1">JSON</a>&nbsp;
           (<a href="/docs#/private/get_responses_responses_get">docs</a>)
         </li>
         <li>


### PR DESCRIPTION
**What does this PR implement?**
This PR downloads the responses as CSV files. Now they can be used in Excel.

**Reference issues/PRs**
This addresses #50.
