### PR TITLE
MAINT: add button for crowdsourcing user to get new query

### DIFF
--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -145,6 +145,7 @@ async def _get_config(exp: bytes, targets: bytes) -> Dict[str, Any]:
         "debrief": "Thanks!",
         "samplers": {"random": {"module": "RandomSampling"}},
         "max_queries": -1,
+        "skip_button": False,
     }
     exp_config.update(config)
 

--- a/salmon/frontend/public.py
+++ b/salmon/frontend/public.py
@@ -80,6 +80,7 @@ async def _ensure_initialized():
         "n",
         "max_queries",
         "debrief",
+        "skip_button",
     ]
     if not set(exp_config) == set(expected_keys):
         msg = "Experiment keys are not correct. Expected {}, got {}"
@@ -101,6 +102,7 @@ async def get_query_page(request: Request):
         "targets": exp_config["targets"],
         "max_queries": exp_config["max_queries"],
         "debrief": exp_config["debrief"],
+        "skip_button": exp_config["skip_button"],
     }
     items.update(request=request)
     return templates.TemplateResponse("query_page.html", items)

--- a/templates/query_page.html
+++ b/templates/query_page.html
@@ -7,6 +7,10 @@
 
 <!-- Bootstrap CSS -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
 <title>Salmon</title>
 <style>
@@ -53,20 +57,12 @@
 </style>
 </head>
 <body>
-  <!-- Optional JavaScript -->
-  <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-  <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-<br>
 <div class="container">
   <div class="outline justify-content-center">
     <div class="row justify-content-center">
-    <br>
     <p> {{instructions | safe}} </p>
     </div>
-    <br>
+    <!-- <hr> -->
     <div class="row justify-content-center">
       <p>Target:</p>
     </div>
@@ -90,11 +86,15 @@
       <div style="padding: 5px; margin: 5px; color: #888;">
           <span id="num-queries">0</span>{% if max_queries > 0 %}/{{ max_queries }} {% endif %}
       </div>
-      <div id="skip-button">
-        {% if skip_button %}
-        <button type="button" class="btn  btn-outline-info" onclick="getquery()">Skip this question
-        </button>
-        {% endif %}
+      <div style="padding: 5px; margin: 5px; color: #888;">
+        <div id="skip-button">
+          {% if skip_button %}
+          <button type="button" class="btn btn-outline-info btn-sm" onclick="getquery()"
+              data-toggle="tooltip" data-placement="top" data-html="true"
+              title="Skip questions only if you know <em>nothing</em> about the items shown."
+          >Skip this question</button>
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
@@ -114,6 +114,11 @@
 </div>
 
 <script>
+// Enable every tool tip on the page
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/templates/query_page.html
+++ b/templates/query_page.html
@@ -66,9 +66,16 @@
     <br>
     <p> {{instructions | safe}} </p>
     </div>
+    <br>
+    <div class="row justify-content-center">
+      <p>Target:</p>
+    </div>
     <div class="row justify-content-center">
       <div class="col-lg-10 justify-content-center center cell head" id="q-head">
       </div>
+    </div>
+    <div class="row justify-content-center">
+        <p>Comparisons:</p>
     </div>
     <div class="row justify-content-center" id="choices">
       <div class="cell answer col col-lg-5 center cell answer" id="q-left"></div>
@@ -85,7 +92,8 @@
       </div>
       <div id="skip-button">
         {% if skip_button %}
-        <button type="button" class="btn btn-light" onclick="getquery()">New query</button>
+        <button type="button" class="btn  btn-outline-info" onclick="getquery()">Skip this question
+        </button>
         {% endif %}
       </div>
     </div>

--- a/templates/query_page.html
+++ b/templates/query_page.html
@@ -81,10 +81,12 @@
   <div class="outline justify-content-center">
     <div class="fixed-bottom">
       <div style="padding: 5px; margin: 5px; color: #888;">
-          <span id="num-queries">0</span>
-          {% if max_queries > 0 %}
-          /{{ max_queries }}
-          {% endif %}
+          <span id="num-queries">0</span>{% if max_queries > 0 %}/{{ max_queries }} {% endif %}
+      </div>
+      <div id="skip-button">
+        {% if skip_button %}
+        <button type="button" class="btn btn-light" onclick="getquery()">New query</button>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/tests/data/button.yaml
+++ b/tests/data/button.yaml
@@ -1,0 +1,11 @@
+# filename: exp.yaml
+targets:
+  - object 1
+  - <i><b>arbitrary HTML</b></i>
+  - <img alt="bode miller" src="https://www.denverpost.com/wp-content/uploads/2005/02/bode-miller-one-ski.jpg" />
+  - <img alt="hoby cat" src="https://cdn.hobiecat.com/digital_asset_profiles/wildcat-action-12-full_jpg_1600x1600__generated.jpg" />
+  - <img alt="bode miller" src="https://nbcolympictalk.files.wordpress.com/2013/11/bode-miller.jpg" />
+instructions: These are <b>instructions</b>!
+max_queries: 10
+debrief: Thanks for participating!
+skip_button: true


### PR DESCRIPTION
**What does this PR implement?**
It adds a skip button. This is relevant if the user doesn't know much about the query. This is especially useful for domain experts.

Here's a screenshot:

<img width="414" alt="Screen Shot 2020-07-16 at 3 19 58 PM" src="https://user-images.githubusercontent.com/1320475/87718849-1c1eb980-c778-11ea-9fbc-f03e3aaa771d.png">

This is specified in the YAML:

``` yaml
targets: [1, 2, 3, 4, 5, 6, 7]
instructions: "Click"
debrief: Thanks!
skip_button: true
```

**Reference issues/PRs**
Related to #50. Documentation will be added in #47.

