### PR TITLE
MAINT: run searches and updates in parallel

### DIFF
--- a/salmon/backend/alg.py
+++ b/salmon/backend/alg.py
@@ -73,6 +73,7 @@ class Runner:
                 f1 = submit("process_answers", self_future, answers)
                 if update:
                     self.clear_queries(rj)
+
                 _start = time()
                 if hasattr(self, "get_queries"):
                     queries_searched = 0

--- a/salmon/triplets/algs/_adaptive_runners.py
+++ b/salmon/triplets/algs/_adaptive_runners.py
@@ -115,6 +115,9 @@ class Adaptive(Runner):
         return queries, scores
 
     def process_answers(self, answers: List[Answer]):
+        if not len(answers):
+            return self, False
+
         self.meta["num_ans"] += len(answers)
         logger.debug("self.meta = %s", self.meta)
         logger.debug("self.R, self.n = %s, %s", self.R, self.n)
@@ -133,6 +136,7 @@ class Adaptive(Runner):
         self.opt.push(alg_ans)
         self.opt.partial_fit(alg_ans)
         self.meta["model_updates"] += 1
+        return self, True
 
     def get_model(self) -> Dict[str, Any]:
         return {

--- a/salmon/triplets/algs/_random_sampling.py
+++ b/salmon/triplets/algs/_random_sampling.py
@@ -48,4 +48,7 @@ class RandomSampling(Runner):
         return query, -9999
 
     def process_answers(self, ans: List[Answer]):
+        if not len(ans):
+            return self, False
         self.answers.extend(ans)
+        return self, True

--- a/salmon/triplets/algs/_round_robin.py
+++ b/salmon/triplets/algs/_round_robin.py
@@ -57,5 +57,8 @@ class RoundRobin(Runner):
         return {"head": int(head), "left": int(a), "right": int(b)}, float(score)
 
     def process_answers(self, ans: List[Answer]):
+        if not len(ans):
+            return self, False
         logger.info(f"p_a, self.counter={self.counter}, len(ans)={len(ans)}")
         self.answers.extend(ans)
+        return self, True

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -64,7 +64,9 @@ def test_round_robin(server, logs):
 
         r = server.get("/responses")
         df = pd.DataFrame(r.json())
-        assert all(df["head"] == np.arange(2 * n) % n)
+        assert set(df["head"].unique()) == set(range(11))
+        diffs = np.abs(df["head"].diff().unique())
+        assert {int(d) for d in diffs if not np.isnan(d)} == {1, 10}
 
     # A traceback I got in this test once. I think I've fixed but am not sure;
     # my tests pass, but I'm not certain this error is deterministic.

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -61,6 +61,7 @@ def test_round_robin(server, logs):
 
             ans = {"winner": random.choice([q["left"], q["right"]]), "puid": "foo", **q}
             server.post("/answer", data=ans)
+            sleep(1)
 
         r = server.get("/responses")
         df = pd.DataFrame(r.json())

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -48,6 +48,7 @@ def test_init_errors_propogate(server):
     assert r.status_code == 500
     assert "module 'salmon.triplets.algs' has no attribute 'foobar'" in r.text
 
+
 def test_run_errors_logged(server, logs):
     server.authorize()
     server.get("/init_exp")
@@ -58,5 +59,9 @@ def test_run_errors_logged(server, logs):
         with logs:
             for k in range(10):
                 q = server.get("/query").json()
-                ans = {"winner": random.choice([q["left"], q["right"]]), "puid": "", **q}
+                ans = {
+                    "winner": random.choice([q["left"], q["right"]]),
+                    "puid": "",
+                    **q,
+                }
                 server.post("/answer", data=ans)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,7 +41,7 @@ def test_basics(server, logs):
     answers = []
     print("Starting loop...")
     with logs:
-        for k in range(30):
+        for k in range(50):
             _start = time()
             q = server.get("/query").json()
             ans = {"winner": random.choice([q["left"], q["right"]]), "puid": puid, **q}
@@ -83,8 +83,9 @@ def test_basics(server, logs):
     }
     n = len(exp_config["targets"])
     assert (0 == df["head"].min()) and (df["head"].max() == n - 1)
-    assert (0 == df["left"].min()) and (df["left"].max() == n - 1)
-    assert (0 == df["right"].min()) and (df["right"].max() == n - 1)
+    assert ((0 == df["left"].min()) or (df["right"].min() == 0)) and (
+        (df["left"].max() == n - 1) or (df["right"].max() == n - 1)
+    )
     assert 10e-3 < df.response_time.min()
     assert expected_cols == set(df.columns)
     assert df.puid.nunique() == 1
@@ -95,7 +96,7 @@ def test_basics(server, logs):
     assert r.status_code == 200
     assert "exception" not in r.text
     df = pd.DataFrame(r.json())
-    assert len(df) == 30
+    assert len(df) == 50
 
     r = server.get("/dashboard", auth=(username, password))
     assert r.status_code == 200
@@ -226,7 +227,7 @@ def test_logs(server, logs):
         query_logs = logs["salmon.frontend.public.log"]
 
         str_answers = [q.strip("\n") for q in query_logs if "answer received" in q]
-        answers = [ast.literal_eval(q[q.find("{"):]) for q in str_answers]
+        answers = [ast.literal_eval(q[q.find("{") :]) for q in str_answers]
         puids = {ans["puid"] for ans in answers}
         assert {str(i) for i in range(10)}.issubset(puids)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -82,7 +82,6 @@ def server():
     r = server.get("/reset?force=1", auth=(username, password))
     assert r.json() == {"success": True}
     sleep(4)
-    _clear_logs()
     dump = Path(__file__).absolute().parent.parent / "out" / "dump.rdb"
     if dump.exists():
         dump.unlink()
@@ -105,6 +104,7 @@ class Logs:
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is not None:
             raise exc_type(exc_value)
+        sleep(1)
         for log in self.log_dir.glob("*.log"):
             lines = log.read_text().split("\n")
             for line in lines:
@@ -112,6 +112,7 @@ class Logs:
                     raise LogError("{}\n{}".format(log, line))
                 if self.warn and "warn" in line:
                     warn("{}\n{}".format(log, line))
+        _clear_logs()
 
 @pytest.fixture()
 def logs():


### PR DESCRIPTION
**What does this PR implement?**
It runs the query search and model updates in parallel. Functionally, it implements this code:

``` python
while True:
    future = client.submit(update)
    for pwr in itertools.count(start=10):
        queries = get_queries(num=2**pwr)
        if future.done():
            break
```

This PR also does the following:

* Better handles errors (and reworks some of the tests)

**Reference issues/PRs**
This PR will close #61 and will close #35.
