### PR TITLE
MAINT: limit queries searched

### DIFF
--- a/salmon/triplets/algs/_adaptive_runners.py
+++ b/salmon/triplets/algs/_adaptive_runners.py
@@ -134,7 +134,7 @@ class Adaptive(Runner):
         rng = None
         if random_state:
             rng = check_random_state(random_state)
-        for pwr in itertools.count(start=13):
+        for pwr in range(12, 20 + 1):
             queries, scores = self.search.score(num=2 ** pwr, random_state=rng)
             ret_queries.append(queries)
             ret_scores.append(scores)

--- a/salmon/triplets/algs/adaptive/_embed.py
+++ b/salmon/triplets/algs/adaptive/_embed.py
@@ -198,6 +198,8 @@ class Embedding(_Embedding):
             self.meta_["model_updates"] += 1
             logger.info("%s", self.meta_)
             if self.meta_["num_grad_comps"] >= eg_deadline:
+                del loss
+                del losses
                 break
         return self
 


### PR DESCRIPTION
**What does this PR implement?**
It limits the number of queries searched to 2^21. This prevents Dask workers and the database from being overloaded.

**Reference issues/PRs**

