### PR TITLE
MAINT: only use Skorch for initialization

### DIFF
--- a/salmon/triplets/algs/_adaptive_runners.py
+++ b/salmon/triplets/algs/_adaptive_runners.py
@@ -91,7 +91,7 @@ class Adaptive(Runner):
         if scorer == "infogain":
             search = InfoGainScorer(
                 embedding=self.opt.embedding(),
-                probs=self.opt.module_.probs,
+                probs=self.opt.net_.module_.probs,
                 random_state=random_state,
             )
         elif scorer == "uncertainty":


### PR DESCRIPTION
**What does this PR implement?**
It removes spaghetti code around Skorch. In v0.4.5 and v0.4.4, I only use Skorch for initialization, but `_embed.Embedding` still inherits from Skorch's NeuralNet. This PR removes that.

**Reference issues/PRs**

