### PR TITLE
MAINT: better initialization

### DIFF
--- a/salmon/backend/alg.py
+++ b/salmon/backend/alg.py
@@ -189,6 +189,7 @@ class Runner:
         reset = rj.jsonget("reset")
         logger.info("reset=%s for %s", reset, self.ident)
         rj.jsonset(f"stopped-{self.ident}", Path("."), True)
+        client.restart()
         return True
 
     @property


### PR DESCRIPTION
**What does this PR implement?**
This PR does the following:

* Raises errors if re-initializing on an already populated database
* Makes sure to restart the Dask worker

**Reference issues/PRs**

This addresses #82 and #88.

