### PR TITLE
DOC: troubleshoot the launching process

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,12 +5,17 @@ This pages details how to get Salmon running, either on EC2 or locally on your
 machine. After you get Salmon running, detail on how to launch experiments in
 :ref:`getting-started`.
 
+.. note::
+
+   See the `Troubleshooting`_ section if you're having difficulties with either
+   of the processes below.
+
 Experimentalist
 ---------------
 
 1. Sign into Amazon AWS (http://aws.amazon.com/)
 2. Select the "Oregon" region (or ``us-west-2``) in the upper right.
-3. Go to Amazon EC2
+3. Go to Amazon EC2.
 4. Launch a new instance (the big blue button or square orange button).
 5. Select AMI ``ami-0e3134e3437ec5b85`` titled "Salmon". It appears in
    Community AMIs after searching "Salmon".
@@ -77,7 +82,7 @@ To start using Salmon, these endpoints will be available:
 Local machine
 -------------
 
-On your local machine as a developer? To launch, first download the code.  It's
+This process is meant for developers. To launch, first download the code.  It's
 possible to download `a ZIP file of Salmon's source`_, or if Git is installed,
 to run this command:
 
@@ -117,3 +122,31 @@ build, up}``.
 
 If you run the command ``export SALMON_NO_AUTH=1``, the Salmon server will
 not require a username/password.
+
+Troubleshooting
+---------------
+
+I can't access Salmon's URL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Try using ``http://`` instead of ``https://``.  By default, EC2 does not
+support HTTPS, and some browsers use HTTPS automatically.
+
+I can't find Salmon's AMI
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Are you in EC2's Oregon region, ``us-west-2``? That can be changed in the upper
+right of the Amazon EC2 interface.
+
+The Salmon AMI has been created in the ``us-west-2`` region, and EC2 AMIs are
+only available in the regions they're created in.
+
+The Docker machines aren't launching
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Are you using the command ``docker-compose up`` to launch Salmon? The command
+``docker build .`` doesn't work.
+
+Salmon requires a Redis docker machine and certain directories/ports being
+available. Technically, it's possible to build all the Docker machines
+yourself (but it's not feasible).

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -76,13 +76,19 @@ To start using Salmon, these endpoints will be available:
 
 Local machine
 -------------
-On your local machine as a developer? Run this following code in a terminal:
+
+On your local machine as a developer? To launch, first download the code.  It's
+possible to download `a ZIP file of Salmon's source`_, or if Git is installed,
+to run this command:
+
+.. _a ZIP file of Salmon's source: https://github.com/stsievert/salmon/archive/refs/heads/master.zip
 
 .. code:: shell
 
    $ git clone https://github.com/stsievert/salmon.git
 
-First, `install Docker`_ and `install Git`_. After that, run the following code:
+Then, to launch a local version of Salmon you'll need `Docker Compose`_.
+After that dependency is intalled, run the following code:
 
 .. _install Docker: https://www.docker.com/products/docker-desktop
 .. _install Git: https://git-scm.com/downloads
@@ -94,14 +100,20 @@ First, `install Docker`_ and `install Git`_. After that, run the following code:
    $ docker-compose up
    $ # visit http://localhost:8421/init_exp or http://localhost:8421/docs
 
-Developer
----------
-Follow the instructions for local machine launch.
+.. _Docker Compose: https://docs.docker.com/compose/install/
 
-If you make changes to this code, follow these instructions:
+If you make changes to this code, run these commands:
 
 .. code:: shell
 
 	$ docker-compose stop
 	$ docker-compose build
 	$ docker-compose up
+
+If you run the command ``export SALMON_DEBUG=1``, the Salmon server will watch
+for changes in the source and re-launch as necessary. This won't be perfect,
+but it will reduce the number of times required to run ``docker-compose {stop,
+build, up}``.
+
+If you run the command ``export SALMON_NO_AUTH=1``, the Salmon server will
+not require a username/password.


### PR DESCRIPTION
**What does this PR implement?**
It clarifies the process for a local launch. Specifically, it does the following:

* Specifies to use Docker Compose instead of manually building the Docker images.
* Collects installation tips in a "troubleshooting" section
* Adds a note about why the correct EC2 region is necessary.

**Reference issues/PRs**
This closes #102.