### PR TITLE
MAINT/ENH: keep scores for ARR

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -23,6 +23,7 @@ we can provide bounds on how many responses you'll need:
   will likely be generated with :math:`O(nd\log_2(n))` responses, likely
   :math:`20 nd \log_2(n)` responses (or possibly :math:`10 nd \log_2(n)`). [2]_
 
+
 This suggests that the number of responses required when :math:`n` and
 :math:`d` are changed scaled like :math:`nd\log_2(n)`.  i.e, if an embedding
 below requires 5,000 responses for :math:`n=30`, scaling to :math:`n=40` with
@@ -31,14 +32,36 @@ below requires 5,000 responses for :math:`n=30`, scaling to :math:`n=40` with
 
 See the :ref:`benchmarks on active sampling <experiments>` for some
 benchmarks/landmarks on the specific number of responses required for a
-particular dataset.
+particular dataset. **If you think your dataset will require too many
+responses,** see :ref:`our recommendations on active samplers
+<adaptiveconfig>`. Active samplers might be able to generate better embeddings
+with a fixed number of responses.
 
-What adaptive algorithms are recommended?
------------------------------------------
+.. _adaptiveconfig:
+
+What active samplers are recommended?
+-------------------------------------
 
 Use of :class:`~salmon.triplets.samplers.ARR` is most recommended.  See the
-:ref:`benchmarks on active sampling <experiments>` for an example
-configuration and the number of responses required for that usage.
+:ref:`benchmarks on active sampling <experiments>` for an example configuration
+and the number of responses required for that usage.  The defaults of
+:class:`~salmon.triplets.samplers.ARR` have been explored pretty throughly. In
+the :ref:`benchmarks on active sampling <experiments>`, we used the default
+parameters for :class:`~salmon.triplets.samplers.ARR` (or changed them to
+figure out what the default should be).
+
+Monitoring performance is difficult with active/adaptive algorithm; random
+sampling is a lot better. Typically, between 10% and 20% of the sampling is
+used to monitor and report performance. That means I'd recommend this partial
+configuration:
+
+.. code-block:: yaml
+
+   samplers:
+     ARR: {}
+     Random: {}
+   sampling:
+     probs: {"ARR": 85, "Random": 15}
 
 Can I choose a different machine?
 ---------------------------------
@@ -64,7 +87,7 @@ EC2, this will require some port forwarding to your own machine:
 
 .. code:: shell
 
-   ssh -i key.pem -L 7787:localhost:8787 ubuntu@34.222.199.114
+   ssh -i key.pem -L 7787:localhost:8787 ubuntu@[EC2 public DNS or IP]
    # visit http://localhost:7787 in the browser to see Salmon's Dask dashboard
 
 If desired, it is possible to open port 8787 on the Amazon EC2 machine. If that

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -6,6 +6,26 @@ FAQ
 Also relevant is the :ref:`troubleshooting`, which goes over some (blocking)
 difficulties while launching.
 
+When should I use random/active sampling?
+-----------------------------------------
+
+Rule of thumb:
+
+* Use random sampling for simple problems when not many responses are required
+  (small number of targets and clean responses).
+* Use active sampling for anything more complicated (large number of targets or
+  noisy responses) when the crowdsourcing budget and/or embedding quality are
+  relevant.
+
+Specifics are :ref:`faq-n_responses` and :ref:`adaptiveconfig`. Random sampling
+can produce good embeddings, but will require about 3× the number of responses
+that active sampling requires.
+
+By default, Salmon will produce random embeddings. This is the simplest
+sampler, and doesn't require any user configuration. Tips on how to use active
+samplers are in :ref:`adaptiveconfig`.
+
+
 .. _faq-n_responses:
 
 How many responses will be needed?
@@ -47,8 +67,8 @@ Use of :class:`~salmon.triplets.samplers.ARR` is most recommended.  See the
 and the number of responses required for that usage.  The defaults of
 :class:`~salmon.triplets.samplers.ARR` have been explored pretty throughly. In
 the :ref:`benchmarks on active sampling <experiments>`, we used the default
-parameters for :class:`~salmon.triplets.samplers.ARR` (or changed them to
-figure out what the default should be).
+parameters for :class:`~salmon.triplets.samplers.ARR` after exploring the
+possible values.
 
 Monitoring performance is difficult with active/adaptive algorithm; random
 sampling is a lot better. Typically, between 10% and 20% of the sampling is

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -101,11 +101,28 @@ Here's an example ``init.yaml`` YAML file for initialization:
      debrief: Thanks! Use the participant ID below in Mechnical Turk.
      max_queries: 100
 
-The top-level elements like ``max_queries`` and ``targets`` are called "keys"
-in YAML jargon. Here's documentation for each key:
+This file will initialize a basic experiment. To do anything fancier,
+additional configuration is required. Here's some documentation on each
+top-level element like ``html``, a "key" in YAML-jargon:
 
 
-* ``html``. Style options for the crowdsourcing user's query page:
+* ``targets``, optional list. Choices:
+
+    * Upload a ZIP file, detailed at :ref:`yaml_plus_zip`.  This will replace
+      the ``targets`` key with the HTML rendering of the contents of the ZIP
+      file.
+
+    * list of HTML targets. Specifying
+      ``targets: ["vonn", "miller", "ligety", "shiffrin"]``
+      will show text to the user. If this text includes HTML, it will be
+      rendered. For example if one target is ``"<i>kildow</i>"`` the user will
+      see italic text when that target is displayed.
+
+* ``samplers``, optional.  **Customizing this key is likely of interest and can
+  generate better embeddings.** See ":ref:`adaptive-config`" for more detail, and
+  ":ref:`experiments`" for examples/benchmarks.
+
+* ``html``, optional. Style options for the crowdsourcing user's query page:
 
     * ``instructions``: text. The instructions for the participant, shown above
       each query.
@@ -127,8 +144,6 @@ in YAML jargon. Here's documentation for each key:
     * ``arrow_keys`` optional boolean, default True. If True, allow users to
       answer queries with the arrow keys.
 
-* ``samplers``. See :ref:`adaptive-config` for more detail.
-
 * ``d``, optional int (default=2). The embedding the samplers should embed into.
 
 * ``sampling``, optional. A dictionary with the following keys:
@@ -140,23 +155,15 @@ in YAML jargon. Here's documentation for each key:
       number of samplers each user sees. If ``samplers_per_user=0``, show
       users a random sampler.
 
-* ``targets``, optional list. Choices:
-
-    * Upload a ZIP file.  This will replace the ``targets`` key with the HTML
-      rendering of the contents of the ZIP file.
-
-    * list of HTML targets. Specifying
-      ``targets: ["vonn", "miller", "ligety", "shiffrin"]``
-      will show text to the user. If this text includes HTML, it will be
-      rendered. For example if one target is ``"<i>kildow</i>"`` the user will
-      see italic text when that target is displayed.
-
 Examples of these files are in `salmon/examples`_. A complete example is
 available at `salmon/examples/complete.yaml`_.
+
 
 .. _salmon/tests/data: https://github.com/stsievert/salmon/tree/master/tests/data
 .. _salmon/examples: https://github.com/stsievert/salmon/tree/master/examples
 .. _salmon/examples/complete.yaml: https://github.com/stsievert/salmon/tree/master/examples/complete.yaml
+
+.. _yaml_plus_zip:
 
 YAML file with ZIP file
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -85,9 +85,6 @@ Now, let's describe three methods on how to launch this experiment:
 Experiment initialization with YAML file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This section will specify the YAML file; including a ZIP file will only modify
-the ``targets`` key.
-
 "YAML files" must obey a standard; see for a (human-readable) description of
 the specification https://learnxinyminutes.com/docs/yaml/. To see if your YAML
 is valid, go to https://yamlchecker.com/.
@@ -103,11 +100,6 @@ Here's an example ``init.yaml`` YAML file for initialization:
      instructions: Select the item on the bottom most similar to the item on the top.
      debrief: Thanks! Use the participant ID below in Mechnical Turk.
      max_queries: 100
-   samplers:
-     ARR: {}
-     Random: {}
-   sampling:
-     probs: {"ARR": 80, "Random": 20}
 
 The top-level elements like ``max_queries`` and ``targets`` are called "keys"
 in YAML jargon. Here's documentation for each key:
@@ -169,18 +161,50 @@ available at `salmon/examples/complete.yaml`_.
 YAML file with ZIP file
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-If you upload a ZIP file alongside the ``init.yaml`` YAML file, the ``targets``
-key above will be configured to represent each object in the ZIP file. Here are
-the choices for different files to include in the ZIP file:
+Uploading a ZIP file will completely replace the ``targets`` key. It's
+recommended not to specify it. However, it doesn't matter if you have specified
+it because it will be overwritten.
 
-- A bunch of images/videos. Support extensions
+Here are the choices for different files to include in the ZIP file:
+
+- A single CSV file. Each textual target should be on a new line.
+- A bunch of images/videos. Support extensions:
 
     - Videos: ``mp4``, ``mov``
     - Images: ``png``, ``gif``, ``jpg``, ``jpeg``
 
-- A single CSV file. Each textual target should be on a new line.
 
-For example, this is a valid CSV file that will render textual targets:
+Let's walk through two examples, both with uploading a bunch of images with
+skiers. Both cases will use this ``init.yaml`` file:
+
+.. code-block:: yaml
+
+  # file: init.yaml
+  html:
+    instructions: Select the item on the bottom most similar to the item on the top.
+    debrief: Thanks! Use the participant ID below in Mechanical Turk.
+    max_queries: 100
+
+.. note::
+
+   Uploading a ZIP file completely replaces any specification of the
+   ``targets`` key above. This means that it is not necessary to specify the
+   ``targets`` key when a ZIP file is uploaded because it will be specified
+   automatically.
+
+Images/videos
+"""""""""""""
+
+If I had all these images in a ZIP file (say ``skiers.zip``), I would gather
+all the images into a ZIP file. On macOS, that's possible by selecting all the
+images then control-clicking and selecting "Compress items." On the command
+line, the command ``zip targets.zip *.jpg *.png`` will collect all JPG/PNG
+images into ``targets.zip``.
+
+Text targets
+""""""""""""
+
+This is a valid CSV file that will render textual targets:
 
 .. code-block::
 
@@ -209,6 +233,8 @@ One rendered target will be this image:
 .. raw:: html
 
    <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/8/89/Miller_Bode_2008_002.jpg" />
+
+
 
 Database dump
 ^^^^^^^^^^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,9 +31,10 @@ responses. More detail is in the :ref:`benchmarks on active sampling
 Users
 =====
 
-Salmon is currently being actively used by several  psychologists at the
-University of Wisconsin--Madison, and has seen serious interest from the Air
-Force Research Lab and a psychologist at Louisiana State University.
+Salmon is currently being actively used by several psychologists at the
+University of Wisconsin--Madison. It has seen serious interest from the Air
+Force Research Lab, and a psychologist at Louisiana State University and
+Canada's Western University.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Force Research Lab and a psychologist at Louisiana State University.
    getting-started
    monitoring
    offline
-   algorithms
+   samplers
    api
    faq
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,18 +2,19 @@ Welcome to Salmon's documentation!
 ==================================
 
 Salmon is a tool to easily allow collection of "triplet queries." These queries
-are of the form "is object :math:`a` more similar to object :math:`b` or
-:math:`b`?" An example is shown below with facial similarities:
+are relative similarity judgments of the form "is object :math:`a` or :math:`b`
+closer to object :math:`h`?" An example is shown below with facial
+similarities:
 
 .. image:: imgs/query.png
    :width: 300px
    :align: center
 
 These queries are interesting because they provide some relative similarity
-structure: a response might indicate that object :math:`a` is closer to object
-:math:`b` than object :math:`c` as determined by humans and the instructions
-they are given. For example, these triplet queries have been used by
-psychologists to determine what facial emotions human find similar:
+structure: a response might indicate that objects :math:`h` and :math:`a` are
+more similar than objects :math:`h` and :math:`b` as determined by humans and
+the instructions they are given. For example, these triplet queries have been
+used by psychologists to determine what facial emotions human find similar:
 
 .. image:: imgs/face-embedding.png
    :width: 500px

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -2,8 +2,8 @@
 
 .. _alg-config:
 
-Algorithm configuration
-=======================
+Sampler configuration
+=====================
 
 There are many queries to ask about in triplet embedding tasks. Most of these
 queries aren't useful; chances are most queries will have obvious answers and
@@ -31,6 +31,25 @@ By default, ``samplers`` defaults to ``Random: {}``. We have to customize the ``
    targets: ["obj1", "obj2", "foo", "bar", "foobar!"]
    samplers:
      ARR: {}
+     Random: {}
+     Validation: {"n_queries": 10}
+   sampling:
+     probs: {"ARR": 70, "Random": 20, "Validation": 10}
+
+
+.. note::
+
+   Want an unbiased estimate of what the crowd thinks? Don't specify
+   ``samplers``, or use the default ``Random: {}``, which will rely on
+   :class:`~salmon.triplets.samplers.Random`
+
+   Want to generate a better embedding? Worried about the cost of collecting
+   responses? Use ``ARR: {}``, which will rely on
+   :class:`~salmon.triplets.samplers.ARR`.
+
+   Want to measure how well the crowd agrees with one another? Use
+   ``Validation: {}``, which will rely on
+   :class:`~salmon.triplets.samplers.Validation`,
 
 When ``ARR`` is specified as a key for ``samplers``,
 :class:`salmon.triplets.samplers.ARR` is used for the sampling method.

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -385,7 +385,7 @@ class ARR(Adaptive):
             Keyword arguments to pass to :class:`~salmon.triplets.samplers.Adaptive`.
         """
         self.n_top = n_top
-        if scores in ["original", "random"]:
+        if scores not in ["original", "random"]:
             raise ValueError(f"scores={scores} not in ['random', 'original']")
         self.scores = scores
         super().__init__(R=R, module=module, **kwargs)

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -387,7 +387,9 @@ class ARR(Adaptive):
         priority : str, optional (default ``"random"``)
             Determines how queries should be ordered. Setting
             ``priority="random"`` will randomly shuffle queries; setting
-            ``priority="original"`` will perserve the original scores.
+            ``priority="original"`` will perserve the original scores. Setting
+            ``priority="approx"`` will add some noise to the original score
+            ranks.
 
             Regardless of the ``scores`` value, ``n_top`` queries per
             head will be perserved. It is likely most relevant when

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -411,10 +411,10 @@ class ARR(Adaptive):
         elif self.scores == "original":
             r_scores = top_queries["score"].to_numpy()
         elif self.scores == "approx":
-            r_scores = top_queries["score"].to_numpy()
-            diff = r_scores.max() - r_scores.min()
-            eps = diff / 10
-            r_scores += np.random.uniform(100, 100 + eps, size=r_scores.size)
+            # ascending=True -> lowest to highest scores
+            top_queries = top_queries.sort_values(by="score", ascending=True)
+            r_scores = np.linspace(0, 1, num=len(top_queries))
+            r_scores += 100 + np.random.uniform(0, 0.1, size=len(top_queries))
         else:
             msg = f"scores={self.scores} not in ['random', 'original']"
             raise ValueError(msg)

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -385,8 +385,8 @@ class ARR(Adaptive):
             Keyword arguments to pass to :class:`~salmon.triplets.samplers.Adaptive`.
         """
         self.n_top = n_top
-        if scores not in ["original", "random"]:
-            raise ValueError(f"scores={scores} not in ['random', 'original']")
+        if scores not in ["original", "random", "approx"]:
+            raise ValueError(f"scores={scores} not in ['random', 'original', 'approx']")
         self.scores = scores
         super().__init__(R=R, module=module, **kwargs)
 
@@ -410,6 +410,11 @@ class ARR(Adaptive):
             r_scores = np.random.uniform(low=10, high=11, size=len(posted))
         elif self.scores == "original":
             r_scores = top_queries["score"].to_numpy()
+        elif self.scores == "approx":
+            r_scores = top_queries["score"].to_numpy()
+            diff = r_scores.max() - r_scores.min()
+            eps = diff / 10
+            r_scores += np.random.uniform(100, 100 + eps, size=r_scores.size)
         else:
             msg = f"scores={self.scores} not in ['random', 'original']"
             raise ValueError(msg)

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -338,7 +338,14 @@ class TSTE(Adaptive):
 
 
 class ARR(Adaptive):
-    """An asynchronous round robin algorithm.
+    """An adaptive "round robin" sampler.
+
+    .. note::
+
+       This class is usable in it's default configuration. Most of the
+       :ref:`active sampling benchmarks <experiments>` have been run under
+       the default configuration of this class. Please carefully consider
+       any changes to the default parameters.
 
     Notes
     -----
@@ -349,13 +356,6 @@ class ARR(Adaptive):
     If ``n_top > 1``, then in practice, this sampling algorithm randomly asks
     about high scoring queries for each head. Becaues it's asynchronous, it
     randomly selects a head (instead of doing it a round-robin fashion).
-
-    .. note::
-
-       We found this class to perform well in our experiments, some of which are detailed at https://docs.stsievert.com/salmon/benchmarks/active.html
-
-       Please carefully consider any changes to the default parameters.
-       The experiments above have helped inform the defaults for this class.
 
     References
     ----------


### PR DESCRIPTION
**What does this PR implement?**
* API: It allows configuring priority scheme for ARR (either random, original or approx).
* DOC: cleans docs on sampler configuration for new users
* DOC: clarifies relation between `targets` key in `init.yaml` and ZIP file upload.
* DOC: updates some FAQ on random/active sampling decision and configuration

**Reference issues/PRs**

