### PR TITLE
API/DOC/backwards: rework config defaults 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: Documentation build
 
-on: push
-# on:
-  # release:
-    # types: [published]
+# on: push
+on:
+  release:
+    types: [published]
 
 # Only run when release published (not created or edited, etc)
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
           sudo docker ps
     - name: Run all tests
       run: |
+          export GITHUB_ACTIONS=1
           # sudo docker-compose logs -f &  # if debugging; shows logs
           # sudo /usr/share/miniconda/bin/pytest -s
-          sudo /usr/share/miniconda/bin/pytest
+          sudo GITHUB_ACTIONS=1 /usr/share/miniconda/bin/pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,5 +59,5 @@ jobs:
           sudo docker ps
     - name: Run all tests
       run: |
-          sudo docker-compose logs -f &
+          # sudo docker-compose logs -f &  # if debugging; shows logs
           sudo /usr/share/miniconda/bin/pytest -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,6 @@ jobs:
           until curl 127.0.0.1:8421 > /dev/null 2>&1; do :; done  # wait for container to start
           sudo docker ps
     - name: Run all tests
-      run: sudo /usr/share/miniconda/bin/pytest
+      run: |
+          sudo docker-compose logs -f &
+          sudo /usr/share/miniconda/bin/pytest -s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,6 @@ jobs:
           sudo docker ps
     - name: Run all tests
       run: |
-          export GITHUB_ACTIONS=1
           # sudo docker-compose logs -f &  # if debugging; shows logs
           # sudo /usr/share/miniconda/bin/pytest -s
-          sudo GITHUB_ACTIONS=1 /usr/share/miniconda/bin/pytest
+          sudo /usr/share/miniconda/bin/pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,4 +60,5 @@ jobs:
     - name: Run all tests
       run: |
           # sudo docker-compose logs -f &  # if debugging; shows logs
-          sudo /usr/share/miniconda/bin/pytest -s
+          # sudo /usr/share/miniconda/bin/pytest -s
+          sudo /usr/share/miniconda/bin/pytest

--- a/README.md
+++ b/README.md
@@ -39,3 +39,5 @@ queries, scores, meta = sampler.get_queries(num=10_000)
 
 This script allows the data scientist to score queries for an embedding they
 specify.
+
+[semver]:https://semver.org

--- a/docs/source/adaptive.rst
+++ b/docs/source/adaptive.rst
@@ -6,7 +6,7 @@ The API the must conform to below:
 
 .. autosummary::
 
-   salmon.backend.sampler.Runner
+   salmon.backend.sampler.Sampler
 
 This API balances the fundamentally serial nature of adaptive algorithms with
 the parallel context of web servers.
@@ -34,7 +34,7 @@ following:
    async def process_answer(answer):
        db.push(answer)
 
-The :class:`~salmon.backend.sampler.Runner` API balances the two and runs the code
+The :class:`~salmon.backend.sampler.Sampler` API balances the two and runs the code
 to `receive answers` and `process answers` in separate processes.
 `Processing the received answers` is an optimization that needs to be performed
 quickly because ``model.best_query`` depends on the optimization.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,6 +5,22 @@
 API
 ===
 
+Configuration
+-------------
+
+.. autosummary::
+   :toctree: generated/
+
+   salmon.triplets.manager.Config
+
+This configuration has two optional components:
+
+.. autosummary::
+   :toctree: generated/
+
+   salmon.triplets.manager.HTML
+   salmon.triplets.manager.Sampling
+
 Offline embeddings
 ------------------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -44,14 +44,14 @@ following API:
    :toctree: generated/
    :template: class.rst
 
-   salmon.backend.sampler.Runner
+   salmon.backend.sampler.Sampler
 
 This class enables running a triplet embedding algorithm on Salmon: it provides
 convenient hooks to the database like ``get_queries`` and ``post_answers`` if
 you want to customize the running of the algorithm. By default, the algorithm
-uses ``Runner.run`` to run the algorithm.
+uses ``Sampler.run`` to run the algorithm.
 
-Every class below inherits from :class:`~salmon.backend.sampler.Runner`.
+Every class below inherits from :class:`~salmon.backend.sampler.Sampler`.
 
 
 Passive Algorithms

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
     "numpydoc",
+    "sphinxcontrib.autodoc_pydantic",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ html_context = {
     "github_user": "stsievert",  # Username
     "github_repo": "salmon",  # Repo name
     "github_version": "master",  # Version
-    "conf_py_path": "/source/",  # Path in the checkout to the docs root
+    "conf_py_path": "/docs/source/",  # Path in the checkout to the docs root
 }
 
 html_theme_options = {

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -25,7 +25,7 @@ After you have developed these functions, look at other algorithms in
 to figure out inheritance details. In short, the following details are
 important:
 
-* **Inheriting from** :class:`~salmon.backend.alg.Runner`, which enables Salmon
+* **Inheriting from** :class:`~salmon.backend.alg.Sampler`, which enables Salmon
   to work with custom algorithms.
 * **Accepting an** ``ident: str`` keyword argument in ``__init__`` **and
   passing that argument to** ``super().__init__``. (``ident`` is passed to all
@@ -47,7 +47,7 @@ Debugging
 ---------
 
 Let's say you've integrated most of your algorithm into
-:class:`~salmon.backend.sampler.Runner`. Now, you'd like to make sure everything is
+:class:`~salmon.backend.sampler.Sampler`. Now, you'd like to make sure everything is
 working properly.
 
 This script will help:

--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -17,6 +17,11 @@ expects two functions:
     * ``get_queries``, which returns a list of queries and scores. These are
       saved in the database, and popped when a user requests a query.
 
+Use of ``get_queries`` is strongly recommended. Then Salmon's backend relies on
+Dask, which allows for higher throughput (more concurrent users). ``get_query``
+uses a single worker process, so it may get overloaded with a moderate number
+of concurrent users.
+
 For complete documentation, see :ref:`alg-api`. In short, your algorithm should
 be a class that implement ``get_query`` and ``process_answers``.
 
@@ -39,9 +44,6 @@ necessary but are highly encouraged:
   on a new machine.
 * **Ensure query searches are fast enough.** The user will be waiting if
   thousands of users come to Salmon and deplete all the searched queries.
-
-It's not a strong requirement, but I would encourage both ``process_answers``
-and ``get_queries`` to be quick and complete in about a second each.
 
 Debugging
 ---------

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -6,6 +6,8 @@ FAQ
 Also relevant is the :ref:`troubleshooting`, which goes over some (blocking)
 difficulties while launching.
 
+.. _random_vs_active:
+
 When should I use random/active sampling?
 -----------------------------------------
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -6,6 +6,14 @@ FAQ
 Also relevant is the :ref:`troubleshooting`, which goes over some (blocking)
 difficulties while launching.
 
+.. note::
+
+   Please include the version in any bug reports or feature requests.  The
+   version number should look something like ``v0.4.1``. It can be found at
+   ``http://[url]:8421/docs`` or in the downloaded experiment file (found at
+   ``http://[url]:8421/download`` which has a filename like
+   ``exp-2021-05-20T07:31-salmon-v0.4.1.rdb``).
+
 .. _random_vs_active:
 
 When should I use random/active sampling?

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -27,7 +27,6 @@ By default, Salmon will produce random embeddings. This is the simplest
 sampler, and doesn't require any user configuration. Tips on how to use active
 samplers are in :ref:`adaptiveconfig`.
 
-
 .. _faq-n_responses:
 
 How many responses will be needed?
@@ -84,6 +83,7 @@ configuration:
      Random: {}
    sampling:
      probs: {"ARR": 85, "Random": 15}
+
 
 Can I choose a different machine?
 ---------------------------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -1,7 +1,7 @@
 .. _getting-started:
 
-Starting an experiment
-======================
+Getting started
+===============
 
 Launching an experiment to crowdsourcing participants requires following this
 process:
@@ -51,6 +51,7 @@ It is technically possible to recover the username/password with the key file
 
 Experiment initialization
 -------------------------
+
 After a user has been successfully created, hit the back
 button and launch an experiment. You have three options:
 
@@ -58,11 +59,8 @@ button and launch an experiment. You have three options:
 2. Upload of a YAML file describing experiment, and ZIP file for the targets.
 3. Upload of a database dump from Salmon.
 
-These options will be detailed below. Throughout the documentation, the YAML
-file for initialization will be referred to as ``init.yaml``.
-
-After you launch your experiment and vist ``http://[url]:8421``, you will see a query
-page:
+These options are detailed at ":ref:`init`." After you launch your experiment
+and vist ``http://[url]:8421``, you will see a query page:
 
 .. _YAML specification: https://yaml.org/
 
@@ -79,161 +77,6 @@ page:
    Please include the version in any bug reports or feature requests.
    The version number is available at ``http://[url]:8421/docs`` and should look
    something like ``v0.4.1``, typically shown right next to "Salmon."
-
-Now, let's describe three methods on how to launch this experiment:
-
-.. _yamlinitialization:
-
-Experiment initialization with YAML file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-"YAML files" must obey a standard; see for a (human-readable) description of
-the specification https://learnxinyminutes.com/docs/yaml/. To see if your YAML
-is valid, go to https://yamlchecker.com/.
-
-
-Here's an example ``init.yaml`` YAML file for initialization:
-
-.. code-block:: yaml
-
-   # file: init.yaml
-   targets: ["l", "<i>kildow</i>", "t", "<i>ligety</i>"]  # or uploaded via ZIP file
-   html:
-     instructions: Select the item on the bottom most similar to the item on the top.
-     debrief: Thanks! Use the participant ID below in Mechnical Turk.
-     max_queries: 100
-
-This file will initialize a basic experiment. By default, Salmon will do the
-following:
-
-* **Use random sampling.** This is a very simple configuration -- but it may
-  not be what you want. Relevant FAQs:
-
-  * ":ref:`random_vs_active`"
-  * ":ref:`adaptiveconfig`"
-
-* Ask 50 questions before showing the participant ID.
-* Embed into :math:`d=2` dimensions if active samplers are specified.
-
-The defaults for instructions/debrief can be found in
-:class:`~salmon.triplets.manager.HTML`. To do anything fancier, additional
-configuration is required. Here's a basic example:
-
-.. code-block:: yaml
-
-   # file: init.yaml
-   targets: ["l", "<i>kildow</i>", "t", "<i>ligety</i>"]  # or uploaded via ZIP file
-   html:
-     max_queries: 100
-   samplers:
-     ARR: {"random_state": 42}
-     testing:
-       class: Random
-   sampling:
-     probs: {"ARR": 85, "testing": 15}
-     common:
-       d: 3  # embed into 3 dimensions for all active samplers
-
-Configuration documentation can be found at
-:class:`~salmon.triplets.manager.Config`. Examples of these files are in
-`salmon/examples`_. A complete example is available at
-`salmon/examples/complete.yaml`_.
-
-.. _salmon/tests/data: https://github.com/stsievert/salmon/tree/master/tests/data
-.. _salmon/examples: https://github.com/stsievert/salmon/tree/master/examples
-.. _salmon/examples/complete.yaml: https://github.com/stsievert/salmon/tree/master/examples/complete.yaml
-
-.. _yaml_plus_zip:
-
-YAML file with ZIP file
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Uploading a ZIP file will completely replace the ``targets`` key. It's
-recommended not to specify it. However, it doesn't matter if you have specified
-it because it will be overwritten.
-
-Here are the choices for different files to include in the ZIP file:
-
-- A single CSV file. Each textual target should be on a new line.
-- A bunch of images/videos. Support extensions:
-
-    - Videos: ``mp4``, ``mov``
-    - Images: ``png``, ``gif``, ``jpg``, ``jpeg``
-
-
-Let's walk through two examples, both with uploading a bunch of images with
-skiers. Both cases will use this ``init.yaml`` file:
-
-.. code-block:: yaml
-
-  # file: init.yaml
-  html:
-    instructions: >
-        Select the <i>comparison</i> item on the bottom that
-        is most similar to the <i>target</i> item on the top.
-    debrief: <b>Thanks!</b> Use the participant ID below in Mechanical Turk.
-    max_queries: 100
-
-.. note::
-
-   Uploading a ZIP file completely replaces any specification of the
-   ``targets`` key above. This means that it is not necessary to specify the
-   ``targets`` key when a ZIP file is uploaded because it will be specified
-   automatically.
-
-Images/videos
-"""""""""""""
-
-If I had all these images in a ZIP file (say ``skiers.zip``), I would gather
-all the images into a ZIP file. On macOS, that's possible by selecting all the
-images then control-clicking and selecting "Compress items." On the command
-line, the command ``zip targets.zip *.jpg *.png`` will collect all JPG/PNG
-images into ``targets.zip``.
-
-Text targets
-""""""""""""
-
-This is a valid CSV file that will render textual targets:
-
-.. code-block::
-
-   # file: targets.csv. Zipped into targets.csv.zip and uploaded.
-   Bode Miller
-   Lindsey Kildow
-   Mikaela Shiffrin
-   <b>Ted Ligety</b>
-   Paula Moltzan
-   Jessie Diggins
-
-Again, every line here is valid HTML, so the crowdsourcing participant will see
-bolded text for "**Ted Ligety**." That means we can also render images:
-
-.. code-block::
-
-   # file: targets.csv. Zipped into targets.csv.zip and uploaded.
-   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/3/30/Bode_Miller_at_the_2010_Winter_Olympic_downhill.jpg" />
-   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/8/89/Miller_Bode_2008_002.jpg" />
-   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Lindsey_Kildow_Aspen.jpg" />
-   <img width="300px" src="https://commons.wikimedia.org/wiki/File:Michael_Sablatnik_Slalom_Spital_am_Semmering_2008.jpg" />
-   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/e/e9/Kjetil_Jansrud_giant_slalom_Norway_2011.jpg" />
-
-One rendered target will be this image:
-
-.. raw:: html
-
-   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/8/89/Miller_Bode_2008_002.jpg" />
-
-
-
-Database dump
-^^^^^^^^^^^^^
-
-The dashboard offers a link to download the experiment on the dashboard (that
-is, at ``http://[url]:8421/dashboard``). This will download a file called
-``exp-[date]-vX.Y.Z.rdb``. Do not delete the numbers ``X.Y.Z``!
-
-Salmon supports the upload of this file to the same version of Salmon. The
-upload of this file will restore the state of your experiment.
 
 Send the URL to participants
 ----------------------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -52,31 +52,28 @@ It is technically possible to recover the username/password with the key file
 Experiment initialization
 -------------------------
 
-After a user has been successfully created, hit the back
-button and launch an experiment. You have three options:
+Hit the back button to visit ``http://[url]:8421/init`` again after after a
+user has been successfully created. Now, let's launch an experiment! There are
+three options:
 
 1. Upload of a YAML file completely detailing the experiment.
 2. Upload of a YAML file describing experiment, and ZIP file for the targets.
 3. Upload of a database dump from Salmon.
 
-These options are detailed at ":ref:`init`." After you launch your experiment
-and vist ``http://[url]:8421``, you will see a query page:
+These options are detailed at ":ref:`init`." If an experiment is incorrectly
+specified, (hopefully helpful) errors will be raised. After the experiment is
+finished launching, you will see a couple links:
+
+* A link to the dashboard (``http://[url]:8421/dashboard``), an example of
+  which is at ":ref:`exp-monitoring`."
+* A link to the query page to send to crowdsourcing users
+  (``http://[url]:8421/``). An (out-of-date) example:
 
 .. _YAML specification: https://yaml.org/
 
 .. image:: imgs/query_page.png
    :align: center
    :width: 500px
-
-.. note::
-
-   This image is almost certainly out of date.
-
-.. note::
-
-   Please include the version in any bug reports or feature requests.
-   The version number is available at ``http://[url]:8421/docs`` and should look
-   something like ``v0.4.1``, typically shown right next to "Salmon."
 
 Send the URL to participants
 ----------------------------

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -82,6 +82,8 @@ page:
 
 Now, let's describe three methods on how to launch this experiment:
 
+.. _yamlinitialization:
+
 Experiment initialization with YAML file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -95,69 +97,43 @@ Here's an example ``init.yaml`` YAML file for initialization:
 .. code-block:: yaml
 
    # file: init.yaml
-   targets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+   targets: ["l", "<i>kildow</i>", "t", "<i>ligety</i>"]  # or uploaded via ZIP file
    html:
      instructions: Select the item on the bottom most similar to the item on the top.
      debrief: Thanks! Use the participant ID below in Mechnical Turk.
      max_queries: 100
 
-This file will initialize a basic experiment. To do anything fancier,
-additional configuration is required. Here's some documentation on each
-top-level element like ``html``, a "key" in YAML-jargon:
+This file will initialize a basic experiment. By default, Salmon will do the
+following:
 
+* **Use random sampling.** This may not be what you want (though it is very
+  simple). See the FAQ :ref:`random_vs_active` for more detail.
+* Ask 50 questions before showing the participant ID.
+* Embed into :math:`d=2` dimensions if active samplers are specified.
 
-* ``targets``, optional list. Choices:
+The defaults for instructions/debrief can be found in
+:class:`~salmon.triplets.manager.HTML`. To do anything fancier, additional
+configuration is required. Here's a basic example:
 
-    * Upload a ZIP file, detailed at :ref:`yaml_plus_zip`.  This will replace
-      the ``targets`` key with the HTML rendering of the contents of the ZIP
-      file.
+.. code-block:: yaml
 
-    * list of HTML targets. Specifying
-      ``targets: ["vonn", "miller", "ligety", "shiffrin"]``
-      will show text to the user. If this text includes HTML, it will be
-      rendered. For example if one target is ``"<i>kildow</i>"`` the user will
-      see italic text when that target is displayed.
+   # file: init.yaml
+   targets: ["l", "<i>kildow</i>", "t", "<i>ligety</i>"]  # or uploaded via ZIP file
+   html:
+     max_queries: 100
+   samplers:
+     ARR: {"random_state": 42}
+     testing:
+       class: Random
+   sampling:
+     probs: {"ARR": 85, "testing": 15}
+     common:
+       d: 3  # embed into 3 dimensions for all active samplers
 
-* ``samplers``, optional.  **Customizing this key is likely of interest and can
-  generate better embeddings.** See ":ref:`adaptive-config`" for more detail, and
-  ":ref:`experiments`" for examples/benchmarks.
-
-* ``html``, optional. Style options for the crowdsourcing user's query page:
-
-    * ``instructions``: text. The instructions for the participant, shown above
-      each query.
-
-    * ``debrief``: text. The message to show at the end of the experiment. This
-      debrief will show alongside the participant ID (aka "puid", which will be
-      available through in the responses).
-
-    * ``max_queries``: int. The number of queries a participant should answer. Set
-      ``max_queries: -1`` for unlimited queries.
-
-    * ``skip_button``, optional boolean. Default ``false``. If ``true``, show a
-      button that says "new query."
-
-    * ``css``, optional string. Defaults to ``""``. This CSS is inserted in the
-      ``<style>`` tag in the HTML query page. This allows customization of
-      colors/borders/etc.
-
-    * ``arrow_keys`` optional boolean, default True. If True, allow users to
-      answer queries with the arrow keys.
-
-* ``d``, optional int (default=2). The embedding the samplers should embed into.
-
-* ``sampling``, optional. A dictionary with the following keys:
-
-    * ``probs``, a map between sampler names and the percentage that
-      each sampler is selected. By default, all samplers are sampled equally.
-
-    * ``samplers_per_user``: (optional int, default=0). Controls the
-      number of samplers each user sees. If ``samplers_per_user=0``, show
-      users a random sampler.
-
-Examples of these files are in `salmon/examples`_. A complete example is
-available at `salmon/examples/complete.yaml`_.
-
+Configuration documentation can be found at
+:class:`~salmon.triplets.manager.Config`. Examples of these files are in
+`salmon/examples`_. A complete example is available at
+`salmon/examples/complete.yaml`_.
 
 .. _salmon/tests/data: https://github.com/stsievert/salmon/tree/master/tests/data
 .. _salmon/examples: https://github.com/stsievert/salmon/tree/master/examples
@@ -188,8 +164,10 @@ skiers. Both cases will use this ``init.yaml`` file:
 
   # file: init.yaml
   html:
-    instructions: Select the item on the bottom most similar to the item on the top.
-    debrief: Thanks! Use the participant ID below in Mechanical Turk.
+    instructions: >
+        Select the <i>comparison</i> item on the bottom that
+        is most similar to the <i>target</i> item on the top.
+    debrief: <b>Thanks!</b> Use the participant ID below in Mechanical Turk.
     max_queries: 100
 
 .. note::

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -34,12 +34,6 @@ hit "create user."
    Do not lose this username/password! You need the username/password to view
    the dashboard and download the received responses.
 
-.. warning::
-
-   Once a username/password are set, they can not be changed. The
-   username/password will remain the same when Salmon is reset and when the
-   machine Salmon is running on is restarted.
-
 It is technically possible to recover the username/password with the key file
 ``key.pem`` that Amazon AWS provides and the URL above:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -106,8 +106,12 @@ Here's an example ``init.yaml`` YAML file for initialization:
 This file will initialize a basic experiment. By default, Salmon will do the
 following:
 
-* **Use random sampling.** This may not be what you want (though it is very
-  simple). See the FAQ :ref:`random_vs_active` for more detail.
+* **Use random sampling.** This is a very simple configuration -- but it may
+  not be what you want. Relevant FAQs:
+
+  * ":ref:`random_vs_active`"
+  * ":ref:`adaptiveconfig`"
+
 * Ask 50 questions before showing the participant ID.
 * Embed into :math:`d=2` dimensions if active samplers are specified.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,8 +47,8 @@ Canada's Western University.
    samplers
    monitoring
    offline
-   api
    faq
+   api
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,9 +43,10 @@ Canada's Western University.
 
    installation
    getting-started
+   init
+   samplers
    monitoring
    offline
-   samplers
    api
    faq
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,8 +24,8 @@ Only distance is relevant in this embedding, not the vertical/horizontal axes.
 However, if you look closely, you can see two axes: positivity and intensity.
 
 Salmon provides efficient methods for collecting these triplet queries. For
-example, Salmon can generate an accurate embedding from only 1,000 responses in
-certain use cases. For the same use case, other approaches might require 2,000
+example, Salmon can generate an accurate embedding from only 2,800 responses in
+certain use cases. For the same use case, other approaches might require 5,500
 responses. More detail is in the :ref:`benchmarks on active sampling
 <experiments>`.
 

--- a/docs/source/init.rst
+++ b/docs/source/init.rst
@@ -92,8 +92,8 @@ Here are the choices for different files to include in the ZIP file:
 - A single CSV file. Each textual target should be on a new line.
 - A bunch of images/videos. Support extensions:
 
-    - Videos: ``mp4``, ``mov``
-    - Images: ``png``, ``gif``, ``jpg``, ``jpeg``
+  - Videos: ``mp4``, ``mov``
+  - Images: ``png``, ``gif``, ``jpg``, ``jpeg``
 
 
 Let's walk through two examples, both with uploading a bunch of images with
@@ -103,7 +103,7 @@ skiers. Both cases will use this ``init.yaml`` file:
 
   # file: init.yaml
   html:
-    instructions: >
+    instructions: >  # multi-line YAML string
         Select the <i>comparison</i> item on the bottom that
         is most similar to the <i>target</i> item on the top.
     debrief: <b>Thanks!</b> Use the participant ID below in Mechanical Turk.

--- a/docs/source/init.rst
+++ b/docs/source/init.rst
@@ -83,9 +83,10 @@ Complete details on the YAML file are at at
 YAML file with ZIP file
 -----------------------
 
-Uploading a ZIP file will completely replace the ``targets`` key. It's
-recommended not to specify it. However, it doesn't matter if you have specified
-it because it will be overwritten.
+Uploading a ZIP file for targets/stimuli is a small addition to
+":ref:`yamlinitialization`." The only difference is that uploading a ZIP file
+overwrites and configures the ``targets`` key for you (so it's not necessary to
+specify the ``targets`` key when uploading a ZIP file).
 
 Here are the choices for different files to include in the ZIP file:
 
@@ -96,8 +97,10 @@ Here are the choices for different files to include in the ZIP file:
   - Images: ``png``, ``gif``, ``jpg``, ``jpeg``
 
 
-Let's walk through two examples, both with uploading a bunch of images with
-skiers. Both cases will use this ``init.yaml`` file:
+A YAML file must be uploaded describing the experiment in addition to including
+the targets in the ZIP file.  Let's walk through two examples, both with
+uploading a bunch of images with skiers. Both cases will use this ``init.yaml``
+file:
 
 .. code-block:: yaml
 
@@ -166,4 +169,11 @@ is, at ``http://[url]:8421/dashboard``). This will download a file called
 ``exp-[date]-vX.Y.Z.rdb``. Do not delete the numbers ``X.Y.Z``!
 
 Salmon supports the upload of this file to the same version of Salmon. The
-upload of this file will restore the state of your experiment.
+upload of this file will restore the state of your experiment. After this file
+is uploaded, the two machines will become indistinguishable from each other
+(which allows you to download the entire experiment onto your own machine then
+upload it to a completely new machine a month later and start collecting
+responses again).
+
+If you run into errors, the FAQ ":ref:`restorefrombackupfaq`" will likely be
+relevant.

--- a/docs/source/init.rst
+++ b/docs/source/init.rst
@@ -1,0 +1,169 @@
+
+.. _init:
+
+Experiment initialization
+=========================
+
+Throughout the documentation, the YAML file for initialization will be referred
+to as ``init.yaml``.
+
+.. note::
+
+   This method is required even if images/videos are includes in a ZIP file (as
+   described in :ref:`yaml_plus_zip`). Uploading a ZIP file only modifies the
+   ``targets`` "key" in the YAML file.
+
+Now, let's describe three methods on how to launch this experiment:
+
+.. _yamlinitialization:
+
+Experiment initialization with YAML file
+----------------------------------------
+
+"YAML files" must obey a standard; see for a (human-readable) description of
+the specification https://learnxinyminutes.com/docs/yaml/. To see if your YAML
+is valid, go to https://yamlchecker.com/.  Here's an example ``init.yaml`` YAML
+file for initialization:
+
+.. code-block:: yaml
+
+   # file: init.yaml
+   targets: ["l", "<i>kildow</i>", "t", "<i>ligety</i>"]  # or uploaded via ZIP file
+   html:
+     instructions: Select the item on the bottom most similar to the item on the top.
+     debrief: Thanks! Use the participant ID below in Mechnical Turk.
+     max_queries: 100
+
+
+This file will initialize a basic experiment. By default, Salmon will do the
+following:
+
+* **Use random sampling.** This is a very simple configuration -- but it may
+  not be what you want. Relevant FAQs:
+
+  * ":ref:`random_vs_active`"
+  * ":ref:`adaptiveconfig`" This FAQ links to :ref:`alg-config`.
+
+* Ask 50 questions before showing the participant ID.
+* Embed into :math:`d=2` dimensions if active samplers are specified.
+
+The defaults for instructions/debrief can be found in
+:class:`~salmon.triplets.manager.HTML`. To do anything fancier, additional
+configuration is required. Here's a basic example:
+
+.. code-block:: yaml
+
+   # file: init.yaml
+   targets: ["l", "<i>kildow</i>", "t", "<i>ligety</i>"]  # or uploaded via ZIP file
+   html:
+     max_queries: 100
+   samplers:
+     ARR: {"random_state": 42}
+     Random: {}
+   sampling:
+     probs: {"ARR": 85, "Random": 15}
+     common:
+       d: 3  # embed into 3 dimensions for all active samplers
+
+The ``samplers`` controls which methods get to choose queries, and ``sampling``
+controls how multiple samplers interact (i.e., how should a sampler be chosen?)
+Some more details can be found at :ref:`alg-config`.
+
+Complete details on the YAML file are at at
+:class:`~salmon.triplets.manager.Config`. Examples of these files are in
+`salmon/examples`_. A complete example is available at
+`salmon/examples/complete.yaml`_.
+
+.. _salmon/tests/data: https://github.com/stsievert/salmon/tree/master/tests/data
+.. _salmon/examples: https://github.com/stsievert/salmon/tree/master/examples
+.. _salmon/examples/complete.yaml: https://github.com/stsievert/salmon/tree/master/examples/complete.yaml
+
+.. _yaml_plus_zip:
+
+YAML file with ZIP file
+-----------------------
+
+Uploading a ZIP file will completely replace the ``targets`` key. It's
+recommended not to specify it. However, it doesn't matter if you have specified
+it because it will be overwritten.
+
+Here are the choices for different files to include in the ZIP file:
+
+- A single CSV file. Each textual target should be on a new line.
+- A bunch of images/videos. Support extensions:
+
+    - Videos: ``mp4``, ``mov``
+    - Images: ``png``, ``gif``, ``jpg``, ``jpeg``
+
+
+Let's walk through two examples, both with uploading a bunch of images with
+skiers. Both cases will use this ``init.yaml`` file:
+
+.. code-block:: yaml
+
+  # file: init.yaml
+  html:
+    instructions: >
+        Select the <i>comparison</i> item on the bottom that
+        is most similar to the <i>target</i> item on the top.
+    debrief: <b>Thanks!</b> Use the participant ID below in Mechanical Turk.
+    max_queries: 100
+
+.. note::
+
+   Uploading a ZIP file completely replaces any specification of the
+   ``targets`` key above. This means that it is not necessary to specify the
+   ``targets`` key when a ZIP file is uploaded because it will be specified
+   automatically.
+
+Images/videos
+^^^^^^^^^^^^^
+
+If I had all these images in a ZIP file (say ``skiers.zip``), I would gather
+all the images into a ZIP file. On macOS, that's possible by selecting all the
+images then control-clicking and selecting "Compress items." On the command
+line, the command ``zip targets.zip *.jpg *.png`` will collect all JPG/PNG
+images into ``targets.zip``.
+
+Text targets
+^^^^^^^^^^^^
+
+This is a valid CSV file that will render textual targets:
+
+.. code-block::
+
+   # file: targets.csv. Zipped into targets.csv.zip and uploaded.
+   Bode Miller
+   Lindsey Kildow
+   Mikaela Shiffrin
+   <b>Ted Ligety</b>
+   Paula Moltzan
+   Jessie Diggins
+
+Again, every line here is valid HTML, so the crowdsourcing participant will see
+bolded text for "**Ted Ligety**." That means we can also render images:
+
+.. code-block::
+
+   # file: targets.csv. Zipped into targets.csv.zip and uploaded.
+   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/3/30/Bode_Miller_at_the_2010_Winter_Olympic_downhill.jpg" />
+   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/8/89/Miller_Bode_2008_002.jpg" />
+   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/5/5e/Lindsey_Kildow_Aspen.jpg" />
+   <img width="300px" src="https://commons.wikimedia.org/wiki/File:Michael_Sablatnik_Slalom_Spital_am_Semmering_2008.jpg" />
+   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/e/e9/Kjetil_Jansrud_giant_slalom_Norway_2011.jpg" />
+
+One rendered target will be this image:
+
+.. raw:: html
+
+   <img width="300px" src="https://upload.wikimedia.org/wikipedia/commons/8/89/Miller_Bode_2008_002.jpg" />
+
+Database dump
+-------------
+
+The dashboard offers a link to download the experiment on the dashboard (that
+is, at ``http://[url]:8421/dashboard``). This will download a file called
+``exp-[date]-vX.Y.Z.rdb``. Do not delete the numbers ``X.Y.Z``!
+
+Salmon supports the upload of this file to the same version of Salmon. The
+upload of this file will restore the state of your experiment.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,6 +12,8 @@ machine. After you get Salmon running, detail on how to launch experiments in
    See the `Troubleshooting`_ section if you're having difficulties with either
    of the processes below.
 
+.. _Salmon's issue tracker: https://github.com/stsievert/salmon/issues
+
 Experimentalist
 ---------------
 
@@ -136,6 +138,15 @@ Troubleshooting
 
 See :ref:`faq` for more general questions.
 
+.. note::
+
+   Please include the version in any bug reports or feature requests.  The
+   version number should look something like ``v0.4.1``. It can be found at
+   ``http://[url]:8421/docs`` or in the downloaded experiment file (found at
+   ``http://[url]:8421/download`` which has a filename like
+   ``exp-2021-05-20T07:31-salmon-v0.4.1.rdb``).
+
+
 I can't access Salmon's URL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -150,6 +161,9 @@ right of the Amazon EC2 interface.
 
 The Salmon AMI has been created in the ``us-west-2`` region, and EC2 AMIs are
 only available in the regions they're created in.
+
+
+.. _restorefrombackupfaq:
 
 Restoring from a backup didn't work
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/monitoring.rst
+++ b/docs/source/monitoring.rst
@@ -21,9 +21,10 @@ After users respond, the dashboard will show the following information:
 
 .. raw:: html
 
-   <p><b>A live example is visible at
-   <a href="./dashboard.html">dashboard.html</a>.</b> This example doesn't
-   render the images, but they're shown in the static images below. Here are some screenshots from that example:</p>
+   <p><b>A static dashboard is visible at <a
+   href="./dashboard.html">dashboard.html</a>.</b> This example doesn't render
+   the images, but they're shown in the static images below. Here are some
+   screenshots from that example:</p>
 
 Basic information
 -----------------

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -36,7 +36,7 @@ responses). Here's a rule of thumb:
    ``Validation: {}``, which will rely on
    :class:`~salmon.triplets.samplers.Validation`,
 
-Now, let's go over how to configure those classes and an example.
+Now, let's go over how to configure different samplers and an example.
 
 File structure
 --------------
@@ -52,22 +52,26 @@ Part of a ``init.yaml`` configuration file might look like this:
    sampling:
      probs: {"ARR": 85, "Random": 15}
 
-This will create the a versions of :class:`~salmon.triplets.samplers.ARR` with
+This will create a versions of :class:`~salmon.triplets.samplers.ARR` with
 ``random_state=42`` would be created alongside the default version of
 :class:`~salmon.triplets.samplers.Random`. When a query is generated, it will be
 generated from ``ARR`` 85% of the time and from ``Random`` the rest of the
 time. Generally, the keys in ``samplers`` and ``sampling`` follow these general
 rules:
 
-* ``samplers``: controls how one specific sampler behaves (i.e., class
-  initialization). The class is specified each key, and any arguments are
-  passed to the class instance.
+* ``samplers``: controls how one specific sampler behaves (i.e., sampler
+  initialization).
+
+  * The type of sampler is specified by each key (e.g., key ``ARR`` corresponds
+    to :class:`~salmon.triplets.samplers.ARR`), and any arguments are
+    initialization parameters for that object.
+
 * ``sampling``: controls samplers interact. For example:
 
-  * the ``probs`` key controls how frequently each class instance in
+  * the ``probs`` key controls how frequently each sampler in
     ``samplers`` is used
   * the ``common`` key controls sending initialization arguments to `every`
-    class instances.
+    sampler.
   * the ``samplers_per_user`` key controls how many samplers are seen by any
     one user who visits Salmon.
 
@@ -75,10 +79,11 @@ A good default configuration is mentioned in the FAQ ":ref:`adaptiveconfig`"
 The defaults and complete details are in
 :class:`~salmon.triplets.manager.Config`.
 
-Multiple classes of the same name
+Multiple samplers of the same name
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-If two classes with different purposes want to be used, the key ``class`` is
-used:
+
+If two samplers with different purposes want to be used, the key ``class`` is
+used to specify which type of sampler should be used:
 
 .. code-block:: yaml
 
@@ -125,7 +130,7 @@ Note that the argument are documented in
 other are passed to :class:`~salmon.triplets.samplers.Adaptive` as mentioned in
 the docstring of :class:`~salmon.triplets.samplers.ARR`.
 
-If you have multiple arguments for *every* class, you can specify that with the
+If you have multiple arguments for *every* sampler, you can specify that with the
 ``common`` key:
 
 .. code-block:: yaml
@@ -141,7 +146,7 @@ If you have multiple arguments for *every* class, you can specify that with the
        d: 3
        random_state: 42
 
-This would initialize these classes:
+This would initialize these samplers:
 
 .. code-block:: python
 
@@ -149,6 +154,8 @@ This would initialize these classes:
    ARR(module="TSTE", d=3, random_state=42)
    ARR(module="CKL",  d=3, random_state=42)
 
+The documentation for ``ARR`` is available at
+:class:`~salmon.triplets.samplers.ARR`.
 
 Example
 -------

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -14,6 +14,130 @@ Choosing the most useful queries to improve the embedding is the task of
 use all previous responses collected to determine the next query that will help
 improve the embedding the most.
 
+This may not always be of interest: sometimes, the goal is not to generate a
+good embedding, but rather to see how well the crowd agrees with each other, or
+to make sure participants don't influence each other (and each response is
+independent of other responses). Here's a rule of thumb:
+
+.. note::
+
+   **Want an unbiased estimate of what the crowd thinks?** Don't specify
+   ``samplers``, or use the default ``Random: {}``, which will rely on
+   :class:`~salmon.triplets.samplers.Random`
+
+   **Want to generate a better embedding?** Worried about the cost of collecting
+   responses? Use ``ARR: {}``, which will rely on
+   :class:`~salmon.triplets.samplers.ARR`.
+
+   **Want to measure how well the crowd agrees with one another?** Use
+   ``Validation: {}``, which will rely on
+   :class:`~salmon.triplets.samplers.Validation`,
+
+Now, let's go over how to configure those classes and an example.
+
+File structure
+--------------
+
+Part of a ``init.yaml`` configuration file might look like this:
+
+.. code-block:: yaml
+
+   # file: init.yaml
+   samplers:
+     ARR: {random_state: 42}
+     Random: {}
+   sampling:
+     probs: {"ARR": 85, "Random": 15}
+
+This will create the a versions of :class:`~salmon.triplets.samplers.ARR` with
+``random_state=42`` would be created alongside the default version of
+:class:`~salmon.triplets.samplers.Random`. When a query is generated, it will be
+generated from ``ARR`` 85% of the time and from ``Random`` the rest of the
+time. Generally, the keys in ``samplers`` and ``sampling`` follow these general
+rules:
+
+* ``samplers``: creating class instances. The class is specified each key, and
+  any arguments are passed to the class instance.
+* ``sampling``: controls the interactions between samplers. For example:
+
+  * the ``probs`` key controls how frequently each class instance in ``samplers`` is used
+  * the ``common`` key controls sending initialization arguments to `every` class instances.
+
+A good default configuration is mentioned in :ref:`adaptiveconfig`, and
+complete details are in :class:`~salmon.triplets.manager.Config`.
+
+Multiple classes of the same name
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If two classes with different purposes want to be used, the key ``class`` is
+used:
+
+.. code-block:: yaml
+
+   # file: init.yaml
+   samplers:
+     testing:
+       class: Random
+     training:
+       class: Random
+
+This will generate queries from these two samplers with equal probability:
+
+.. code-block:: python
+
+   from salmon.triplets.samplers import Random
+   Random()
+   Random()
+
+Initialization Arguments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Arguments inside each key are passed to the sampler. For example,
+
+.. code-block:: yaml
+
+   # file: init.yaml
+   samplers:
+     ARR:
+       random_state: 42
+       module: CKL
+       d: 3
+       scorer: "uncertainty"
+
+would create this class:
+
+.. code-block:: python
+
+   from salmon.triplets.samplers import ARR
+   ARR(random_state=42, module="CKL", d=3, scorer="uncertainty")
+
+If you have multiple arguments for *every* class, you can specify that with the
+``common`` key:
+
+.. code-block:: yaml
+
+   # file: init.yaml
+   samplers:
+     arr_tste:
+       module: TSTE
+     arr_ckl:
+       module: CKL
+   sampling:
+     common:
+       d: 3
+       random_state: 42
+
+This would initialize these classes:
+
+.. code-block:: python
+
+   from salmon.triplets.samplers import ARR
+   ARR(module="TSTE", d=3, random_state=42)
+   ARR(module="CKL",  d=3, random_state=42)
+
+
+Example
+-------
+
 Let's start out with a simple ``init.yaml`` file, one suited for random
 sampling.
 
@@ -37,20 +161,6 @@ By default, ``samplers`` defaults to ``Random: {}``. We have to customize the ``
      probs: {"ARR": 70, "Random": 20, "Validation": 10}
 
 
-.. note::
-
-   Want an unbiased estimate of what the crowd thinks? Don't specify
-   ``samplers``, or use the default ``Random: {}``, which will rely on
-   :class:`~salmon.triplets.samplers.Random`
-
-   Want to generate a better embedding? Worried about the cost of collecting
-   responses? Use ``ARR: {}``, which will rely on
-   :class:`~salmon.triplets.samplers.ARR`.
-
-   Want to measure how well the crowd agrees with one another? Use
-   ``Validation: {}``, which will rely on
-   :class:`~salmon.triplets.samplers.Validation`,
-
 When ``ARR`` is specified as a key for ``samplers``,
 :class:`salmon.triplets.samplers.ARR` is used for the sampling method.
 Customization is possible by passing different keyword arguments to
@@ -64,29 +174,3 @@ configuration:
      Random: {}
      ARR:
        module: "TSTE"
-
-``module`` is a keyword argument to :class:`~salmon.triplets.samplers.ARR`, and
-determines the noise model used for query scoring/embedding. This configuration
-would compare two different instances of
-:class:`~salmon.triplets.samplers.ARR`:
-
-.. code-block:: yaml
-
-   targets: ["obj1", "obj2", "foo", "bar", "foobar!"]
-
-   samplers:
-     Random: {}
-     arr_tste:
-       class: ARR
-       module: "TSTE"
-     arr_ckl:
-       class: ARR
-       module: "CKL"
-       module__mu: 0.02
-
-   sampling:
-     probs: {"Random": 20, "arr_ckl": 40, "arr_tste": 40}
-
-In this configuration, custom names are provided for two instances of
-:class:`~salmon.triplets.samplers.ARR`. Both instances are sampled 40% of the
-time, with the remaining 20% reserved for a test set with random queries.

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -51,6 +51,7 @@ Part of a ``init.yaml`` configuration file might look like this:
      Random: {}
    sampling:
      probs: {"ARR": 85, "Random": 15}
+     samplers_per_user: 0  # use probability above
 
 This will create a versions of :class:`~salmon.triplets.samplers.ARR` with
 ``random_state=42`` would be created alongside the default version of

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -56,15 +56,21 @@ generated from ``ARR`` 85% of the time and from ``Random`` the rest of the
 time. Generally, the keys in ``samplers`` and ``sampling`` follow these general
 rules:
 
-* ``samplers``: creating class instances. The class is specified each key, and
-  any arguments are passed to the class instance.
-* ``sampling``: controls the interactions between samplers. For example:
+* ``samplers``: controls how one specific sampler behaves (i.e., class
+  initialization). The class is specified each key, and any arguments are
+  passed to the class instance.
+* ``sampling``: controls samplers interact. For example:
 
-  * the ``probs`` key controls how frequently each class instance in ``samplers`` is used
-  * the ``common`` key controls sending initialization arguments to `every` class instances.
+  * the ``probs`` key controls how frequently each class instance in
+    ``samplers`` is used
+  * the ``common`` key controls sending initialization arguments to `every`
+    class instances.
+  * the ``samplers_per_user`` key controls how many samplers are seen by any
+    one user who visits Salmon.
 
-A good default configuration is mentioned in :ref:`adaptiveconfig`, and
-complete details are in :class:`~salmon.triplets.manager.Config`.
+A good default configuration is mentioned in the FAQ ":ref:`adaptiveconfig`"
+The defaults and complete details are in
+:class:`~salmon.triplets.manager.Config`.
 
 Multiple classes of the same name
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +94,7 @@ This will generate queries from these two samplers with equal probability:
    Random()
    Random()
 
-Initialization Arguments
+Initialization arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Arguments inside each key are passed to the sampler. For example,
@@ -103,12 +109,18 @@ Arguments inside each key are passed to the sampler. For example,
        d: 3
        scorer: "uncertainty"
 
-would create this class:
+would create an instance of :class:`~salmon.triplets.samplers.ARR`:
 
 .. code-block:: python
 
    from salmon.triplets.samplers import ARR
    ARR(random_state=42, module="CKL", d=3, scorer="uncertainty")
+
+Note that the argument are documented in
+:class:`~salmon.triplets.samplers.ARR`. Some argument are arguments that
+:class:`~salmon.triplets.samplers.ARR` directly uses (like ``module``), and
+other are passed to :class:`~salmon.triplets.samplers.Adaptive` as mentioned in
+the docstring of :class:`~salmon.triplets.samplers.ARR`.
 
 If you have multiple arguments for *every* class, you can specify that with the
 ``common`` key:

--- a/docs/source/samplers.rst
+++ b/docs/source/samplers.rst
@@ -14,10 +14,13 @@ Choosing the most useful queries to improve the embedding is the task of
 use all previous responses collected to determine the next query that will help
 improve the embedding the most.
 
-This may not always be of interest: sometimes, the goal is not to generate a
-good embedding, but rather to see how well the crowd agrees with each other, or
-to make sure participants don't influence each other (and each response is
-independent of other responses). Here's a rule of thumb:
+If quality embeddings are desired, the benchmarks at ":ref:`experiments`" are
+likely of interest, as are the FAQs on ":ref:`random_vs_active`" and
+":ref:`adaptiveconfig`" However, quality embeddings may not always be of
+interest: sometimes, the goal is not to generate a good embedding, but rather
+to see how well the crowd agrees with each other, or to make sure participants
+don't influence each other (and each response is independent of other
+responses). Here's a rule of thumb:
 
 .. note::
 
@@ -25,8 +28,8 @@ independent of other responses). Here's a rule of thumb:
    ``samplers``, or use the default ``Random: {}``, which will rely on
    :class:`~salmon.triplets.samplers.Random`
 
-   **Want to generate a better embedding?** Worried about the cost of collecting
-   responses? Use ``ARR: {}``, which will rely on
+   **Want to generate a better embedding? Worried about the cost of
+   collecting responses?** Use ``ARR: {}``, which will rely on
    :class:`~salmon.triplets.samplers.ARR`.
 
    **Want to measure how well the crowd agrees with one another?** Use

--- a/examples/alien-eggs/active.yaml
+++ b/examples/alien-eggs/active.yaml
@@ -1,8 +1,8 @@
-d: 2
 samplers:
   ARR:
     module__mu: 0.05
     module: "CKL"
+sampling: {"common": {"d": 2}}
 html:
   instructions: Which of the comparison objects is most similar to the target object?
   debrief: Thanks! Please enter this participant ID in the assignment.

--- a/examples/alien-eggs/random.yaml
+++ b/examples/alien-eggs/random.yaml
@@ -2,6 +2,6 @@ html:
   instructions: Which of the comparison objects is most similar to the target object?
   debrief: Thanks! Please enter this participant ID in the assignment.
   max_queries: 100  # took about 2.05 minutes for 100 queries
-d: 2
+sampling: {"common": {"d": 2}}
 samplers:
   Random: {}

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -1,5 +1,4 @@
 targets: 10
-d: 2
 samplers:
   ARR: {}
   Random: {}
@@ -7,3 +6,5 @@ samplers:
     queries: [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
 sampling:
   probs: {"ARR": 40, "Validation": 40, "Random": 20}
+  common:
+    d: 2

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -1,5 +1,3 @@
-html:
-  max_queries: 100
 targets: 10
 d: 2
 samplers:

--- a/examples/colors/colors.yaml
+++ b/examples/colors/colors.yaml
@@ -19,10 +19,10 @@ html:
     .debrief {
       color: #000;
     }
-d: 2
 samplers:
   ARR:
     random_state: 42
   Random: {}
 sampling:
   probs: {"Random": 38, "ARR": 62}
+  common: {"d": 2}

--- a/examples/complete.yaml
+++ b/examples/complete.yaml
@@ -9,7 +9,6 @@ targets:
   - "<img src=\"https://northiowatoday.com/wp-content/uploads/2014/02/Ligety-693X520.jpg\" />"
   - "<img src='https://seatosummit.net/wp-content/uploads/2014/05/2354763_ml.jpg' />"
   - <img src='https://cdn.getyourguide.com/img/location/5c88dc48eef33.jpeg/88.jpg' />
-d: 2
 samplers:
   Random: {}
   testing:
@@ -20,6 +19,7 @@ samplers:
 sampling:
   probs: {"ARR": 40, "Validation": 20, "Random": 20, "testing": 20}
   samplers_per_user: 0
+  common: {d: 2}
 html:
   instructions: Click buttons, <b>or else.</b>
   debrief: "Thanks! Use the participant ID below:"

--- a/examples/customize.yaml
+++ b/examples/customize.yaml
@@ -1,0 +1,17 @@
+samplers:
+  arr1:
+    class: ARR
+    n_top: 3  # argument to salmon.triplets.samplers.ARR
+    scorer: "infogain"  # argument to salmon.triplets.samplers.Adaptive
+  arr2:
+    class: ARR
+    n_top: 1
+    scorer: "uncertainty"  # argument to salmon.triplets.samplers.Adaptive
+sampling:
+  common:
+    d: 3  # Adaptive
+    random_state: 42  # Adaptive
+    initial_batch_size: 128  # Embedding
+html:
+  instructions: Click buttons, <b>or else.</b>
+targets: 10

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -6,7 +6,6 @@ html:
     <i>target</i> item.
   max_queries: 50
   skip_button: false
-n: 10
 samplers:
   random:
     class: Random

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -1,0 +1,19 @@
+html:
+  arrow_keys: true
+  css: ''
+  debrief: <b>Thanks!</b> Please use the participant ID below.
+  instructions: Please select the <i>comparison</i> item that is most similar to the
+    <i>target</i> item.
+  max_queries: 50
+  skip_button: false
+n: 10
+samplers:
+  random:
+    class: Random
+sampling:
+  common:
+    d: 2
+  probs:
+    random: 100
+  samplers_per_user: 1
+targets: 10  # for completness; actually required

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -6,6 +6,7 @@ html:
     <i>target</i> item.
   max_queries: 50
   skip_button: false
+  title: "Similarity judgements"
 samplers:
   random:
     class: Random
@@ -15,4 +16,4 @@ sampling:
   probs:
     random: 100
   samplers_per_user: 1
-targets: 10  # for completness; actually required
+targets: ["actually", "required", "with", "zip", "or", "yaml"]

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -15,5 +15,5 @@ sampling:
     d: 2
   probs:
     random: 100
-  samplers_per_user: 1
+  samplers_per_user: 0
 targets: ["actually", "required", "with", "zip", "or", "yaml"]

--- a/examples/faces/random.yaml
+++ b/examples/faces/random.yaml
@@ -2,6 +2,5 @@ html:
   instructions: Which of the comparison objects is most similar to the target object?
   debrief: Thanks! Please enter this participant ID in the assignment.
   max_queries: 100  # took about 2.05 minutes for 100 queries
-d: 2
 samplers:
   Random: {}

--- a/examples/zappos/active.yaml
+++ b/examples/zappos/active.yaml
@@ -2,6 +2,7 @@ html:
   instructions: Which of the comparison shoes is most similar to the target shoe?
   debrief: Thanks! Please enter this participant ID in the assignment.
   max_queries: 100
+  title: Zappos shoes
 samplers:
   Random: {}
   ARR: {random_state: 42}

--- a/examples/zappos/active.yaml
+++ b/examples/zappos/active.yaml
@@ -2,9 +2,9 @@ html:
   instructions: Which of the comparison shoes is most similar to the target shoe?
   debrief: Thanks! Please enter this participant ID in the assignment.
   max_queries: 100
-d: 2
 samplers:
   Random: {}
   ARR: {random_state: 42}
 sampling:
   probs: {"ARR": 80, "Random": 20}
+  common: {d: 2}

--- a/launch.sh
+++ b/launch.sh
@@ -3,7 +3,12 @@
 # Currently so don't have to rebuild docker machines; see
 # https://github.com/dask/dask-docker/pull/108
 
-export SALMON_NPROC=$(getconf _NPROCESSORS_ONLN)
+# TODO: _NPROCESSORS_ONLN==1 for github actions. Leads to index error on
+# backend, not enough workers.
+
+
+export NUM_PROCS=$(getconf _NPROCESSORS_ONLN)
+export SALMON_NPROC=$(python -c "print(max(4, $NUM_PROCS))")
 
 # chose nthreads=1 because best practice [1]
 # [1]: https://docs.dask.org/en/latest/array-best-practices.html#avoid-oversubscribing-threads

--- a/launch.sh
+++ b/launch.sh
@@ -41,8 +41,11 @@ else
 
     ## Use uvicorn instead of gunicorn because FastAPI's background tasks are threads
     ## in uvicorn, not processes.
+    ##
+    ## Only use one worker because some global state for sampler.get_query
+    # (not a huge issue because this server is mostly a proxy for Dask)
+    uvicorn salmon:app_algs --workers 1 --port 8400 --host 0.0.0.0 &
     # gunicorn --preload --worker-tmp-dir /dev/shm --threads 2 --timeout 90 -w 1 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8400 salmon:app_algs &
-    uvicorn salmon:app_algs --port 8400 --host 0.0.0.0 &
     sleep 1
     gunicorn --worker-tmp-dir /dev/shm --threads 2 --timeout 90 -w 4 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8421 salmon:app
 fi

--- a/launch.sh
+++ b/launch.sh
@@ -44,6 +44,7 @@ else
     ##
     ## Only use one worker because some global state for sampler.get_query
     # (not a huge issue because this server is mostly a proxy for Dask)
+    # (this breaks down if get_query is relied upon)
     uvicorn salmon:app_algs --workers 1 --port 8400 --host 0.0.0.0 &
     # gunicorn --preload --worker-tmp-dir /dev/shm --threads 2 --timeout 90 -w 1 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8400 salmon:app_algs &
     sleep 1

--- a/salmon.yml
+++ b/salmon.yml
@@ -37,7 +37,7 @@ dependencies:
     - bokeh==2.0.1  # because templates/dashboard.html requires this version
     - cloudpickle
     - jinja2
-    - redis>=3.0.0
+    - redis==3.5.*  # https://github.com/RedisJSON/redisjson-py/issues/67
     - matplotlib
     - gunicorn
     - python-multipart  # optional dep required by gunicorn
@@ -47,3 +47,4 @@ dependencies:
     - sphinx_rtd_theme
     - pytest
     - jupyter-server-proxy  # to view Dask dashboard
+    - autodoc_pydantic  # to show config docs

--- a/salmon/backend/core.py
+++ b/salmon/backend/core.py
@@ -3,6 +3,7 @@ import os
 import random
 import threading
 import traceback
+from copy import deepcopy
 from typing import Dict, Union
 
 import cloudpickle
@@ -109,7 +110,10 @@ async def init(ident: str, background_tasks: BackgroundTasks) -> bool:
             params = {k: _fmt_params(k, v) for k, v in params.items()}
             logger.warning("Sampler for %s = %s", ident, Sampler)
             logger.warning("params = %s", params)
-            alg = Sampler(ident=ident, n=config["n"], d=config["d"], **params)
+            common = config["sampling"]["common"]
+            p = deepcopy(common)
+            p.update(params)
+            alg = Sampler(ident=ident, n=config["n"], **p)
     except Exception as e:
         msg = exception_to_string(e)
         logger.error(f"Error on alg={ident} init: {msg}")

--- a/salmon/backend/core.py
+++ b/salmon/backend/core.py
@@ -156,7 +156,7 @@ def get_query(ident: str):
         if q is None:
             flush_logger(logger)
             raise HTTPException(status_code=404)
-        return {"alg_ident": ident, "score": score, **q}
+        return {"sampler": ident, "score": score, **q}
 
 
 def _fmt_params(k, v):
@@ -167,36 +167,36 @@ def _fmt_params(k, v):
     raise ValueError(f"Error formatting key={k} with value {v}")
 
 
-@app.get("/model/{alg_ident}")
-async def get_model(alg_ident: str):
+@app.get("/model/{sampler}")
+async def get_model(sampler: str):
     samplers = rj.jsonget("samplers")
-    if alg_ident not in samplers:
+    if sampler not in samplers:
         raise ServerException(
-            f"Can't find model for alg_ident='{alg_ident}'. "
-            f"Valid choices for alg_ident are {samplers}"
+            f"Can't find model for sampler='{sampler}'. "
+            f"Valid choices for sampler are {samplers}"
         )
-    if f"model-{alg_ident}" not in rj.keys():
+    if f"model-{sampler}" not in rj.keys():
         logger.warning("rj.keys() = %s", rj.keys())
         flush_logger(logger)
-        raise ServerException(f"Model has not been created for alg_ident='{alg_ident}'")
+        raise ServerException(f"Model has not been created for sampler='{sampler}'")
     rj2 = Client(host="redis", port=6379, decode_responses=False)
-    ir = rj2.get(f"model-{alg_ident}")
+    ir = rj2.get(f"model-{sampler}")
     model = cloudpickle.loads(ir)
     return model
 
 
-@app.get("/meta/perf/{alg_ident}")
-async def get_timings(alg_ident: str):
+@app.get("/meta/perf/{sampler}")
+async def get_timings(sampler: str):
     samplers = rj.jsonget("samplers")
-    if alg_ident not in samplers:
+    if sampler not in samplers:
         raise ServerException(
-            f"Can't find key for alg_ident='{alg_ident}'. "
-            f"Valid choices for alg_ident are {samplers}"
+            f"Can't find key for sampler='{sampler}'. "
+            f"Valid choices for sampler are {samplers}"
         )
     keys = list(sorted(rj.keys()))
-    if f"alg-perf-{alg_ident}" not in keys:
+    if f"alg-perf-{sampler}" not in keys:
         logger.warning("rj.keys() = %s", keys)
         raise ServerException(
-            f"Performance data has not been created for alg_ident='{alg_ident}'. Database has keys {keys}"
+            f"Performance data has not been created for sampler='{sampler}'. Database has keys {keys}"
         )
-    return rj.jsonget(f"alg-perf-{alg_ident}")
+    return rj.jsonget(f"alg-perf-{sampler}")

--- a/salmon/backend/core.py
+++ b/salmon/backend/core.py
@@ -17,7 +17,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from salmon.frontend.utils import ServerException
 
 from ..triplets import samplers
-from ..utils import get_logger, flush_logger
+from ..utils import flush_logger, get_logger
 
 DEBUG = os.environ.get("SALMON_DEBUG", 0)
 

--- a/salmon/backend/sampler.py
+++ b/salmon/backend/sampler.py
@@ -23,10 +23,6 @@ Answer = TypeVar("Answer")
 root = Path.rootPath()
 
 
-class StopRunning(Exception):
-    pass
-
-
 class Sampler:
     """
     Run a sampling algorithm. Provides hooks to connect with the database and

--- a/salmon/backend/sampler.py
+++ b/salmon/backend/sampler.py
@@ -208,16 +208,16 @@ class Sampler:
                             _update = {"time": _update["time_median"]}
                         to_post.update({_k: Type(v) for _k, v in _update.items()})
 
-                    #  try:
-                    rj.jsonarrappend(f"alg-perf-{self.ident}", root, to_post)
-                    #  except ResponseError as e:
-                        #  if "could not perform this operation on a key that doesn't exist" in str(e):
-                            #  # I think this happens when the frontend deletes
-                            #  # the database after the endpoint /reset is
-                            #  # triggered
-                            #  pass
-                        #  else:
-                            #  raise e
+                    try:
+                        rj.jsonarrappend(f"alg-perf-{self.ident}", root, to_post)
+                    except ResponseError as e:
+                        if "could not perform this operation on a key that doesn't exist" in str(e):
+                            # I think this happens when the frontend deletes
+                            # the database after the endpoint /reset is
+                            # triggered
+                            pass
+                        else:
+                            raise e
 
                     data = []
 

--- a/salmon/backend/sampler.py
+++ b/salmon/backend/sampler.py
@@ -12,7 +12,7 @@ from redis.exceptions import ResponseError
 from rejson import Client as RedisClient
 from rejson import Path
 
-from ..utils import get_logger, flush_logger
+from ..utils import flush_logger, get_logger
 
 logger = get_logger(__name__)
 

--- a/salmon/backend/sampler.py
+++ b/salmon/backend/sampler.py
@@ -206,7 +206,17 @@ class Sampler:
                             _update = {"time": _update["time_median"]}
                         to_post.update({_k: Type(v) for _k, v in _update.items()})
 
-                    rj.jsonarrappend(f"alg-perf-{self.ident}", root, to_post)
+                    try:
+                        rj.jsonarrappend(f"alg-perf-{self.ident}", root, to_post)
+                    except ResponseError as e:
+                        if "could not perform this operation on a key that doesn't exist" in str(e):
+                            # I think this happens when the frontend deletes
+                            # the database after the endpoint /reset is
+                            # triggered
+                            pass
+                        else:
+                            raise e
+
                     data = []
 
                 if "reset" in rj.keys() and rj.jsonget("reset", root):

--- a/salmon/backend/sampler.py
+++ b/salmon/backend/sampler.py
@@ -81,6 +81,7 @@ class Sampler:
         save_deadline = 0.0  # right away
         data: List[Dict[str, Any]] = []
 
+        error_raised: List[int] = []
         for k in itertools.count():
             try:
                 loop_start = time()
@@ -228,6 +229,13 @@ class Sampler:
             except Exception as e:
                 logger.exception(e)
                 flush_logger(logger)
+                error_raised.append(k)
+
+                __n = 5
+                if np.diff(error_raised[-__n:]).tolist() == [1] * (__n - 1):
+                    logger.exception(e)
+                    flush_logger(logger)
+                    raise e
         return True
 
     def save(self) -> bool:

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -21,12 +21,8 @@ import requests as httpx
 import yaml
 from bokeh.embed import json_item
 from fastapi import Depends, File, Form, HTTPException
-from fastapi.responses import (
-    FileResponse,
-    HTMLResponse,
-    JSONResponse,
-    PlainTextResponse,
-)
+from fastapi.responses import (FileResponse, HTMLResponse, JSONResponse,
+                               PlainTextResponse)
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from redis import ResponseError
 from rejson import Client, Path
@@ -35,18 +31,13 @@ from starlette.requests import Request
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_409_CONFLICT
 
 import salmon
+from salmon.triplets.manager import Config
 
 from ..triplets import manager
 from . import plotting
 from .public import _ensure_initialized, app, templates
-from .utils import (
-    ServerException,
-    _extract_zipfile,
-    _format_target,
-    _format_targets,
-    get_logger,
-)
-from salmon.triplets.manager import Config
+from .utils import (ServerException, _extract_zipfile, _format_target,
+                    _format_targets, get_logger)
 
 security = HTTPBasic()
 

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -941,7 +941,7 @@ async def download(request: Request, authorized: bool = Depends(_authorize)):
     fname = datetime.now().isoformat()[: 10 + 6]
     version = salmon.__version__
     headers = {
-        "Content-Disposition": f'attachment; filename="exp-{fname}-{version}.rdb"'
+        "Content-Disposition": f'attachment; filename="exp-{fname}-salmon-{version}.rdb"'
     }
     return FileResponse(str(ROOT_DIR / "out" / "dump.rdb"), headers=headers)
 

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -553,20 +553,14 @@ def _reset(timeout: float = 5):
 
     logger.warning("Trying to completely flush database...")
 
-    rj.flushall(asynchronous=True)
-    rj2.flushall(asynchronous=True)
-    rj.flushdb(asynchronous=True)
-    rj2.flushdb(asynchronous=True)
     for _rj in [rj, rj2]:
         _rj.memory_purge()
-        sleep(1)
-        for k in _rj.keys():
-            _rj.delete(k)
         _rj.flushall(asynchronous=True)
         _rj.flushdb(asynchronous=True)
-        sleep(1)
+        _rj.memory_purge()
+        for k in _rj.keys():
+            _rj.delete(k)
         _rj.flushdb(asynchronous=False)
-        sleep(1)
         _rj.flushall(asynchronous=False)
 
     now = datetime.now().isoformat()[: 10 + 6]
@@ -642,12 +636,11 @@ def _fmt_embedding(
     for k, v in kwargs.items():
         df[k] = v
 
-    embedding = np.asarray(embedding)
-    if embedding.ndim == 1:
-        embedding = embedding.reshape(1, -1)
-    for k, col in enumerate(range(embedding.shape[1])):
-        df[k] = embedding[:, col]
-
+    em = np.asarray(embedding)
+    if em.ndim == 1:
+        em = em.reshape(1, -1)
+    for k2, col in enumerate(range(em.shape[1])):
+        df[k2] = em[:, col]
     return df
 
 

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -937,7 +937,7 @@ async def download(request: Request, authorized: bool = Depends(_authorize)):
     This file can be used to restore the contents of the Redis
     database on a new machine.
     """
-    _save(rj, bg=True)
+    _save(rj, bg=False)
     fname = datetime.now().isoformat()[: 10 + 6]
     version = salmon.__version__
     headers = {

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -297,11 +297,11 @@ async def _get_config(exp: bytes, targets: bytes) -> Dict[str, Any]:
     logger.warning(f"config = {config}")
 
     html = {
-        "instructions": "Default instructions (can include <i>arbitrary</i> HTML)",
-        "debrief": "Thanks!",
+        "instructions": "Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.",
+        "debrief": "<b>Thanks!</b> Please use the participant ID below.",
         "skip_button": False,
         "css": "",
-        "max_queries": -1,
+        "max_queries": 50,
         "arrow_keys": True,
     }
     exp_config: Dict = {

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -298,9 +298,7 @@ async def _get_config(exp: bytes, targets: bytes) -> Dict[str, Any]:
     logger.warning(f"user_config = {user_config}")
 
     c = Config()  # defaults already encoded
-    c.update(user_config)
-    c = c.parse_obj(user_config)
-    c.validate()
+    c = c.parse(user_config)
     config = c.dict()
 
     logger.warning(config["sampling"]["probs"])

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -286,6 +286,7 @@ def upload_form():
 @app.get("/config", tags=["private"])
 async def _get_config_endpoint(json: bool = True):
     exp_config = await _ensure_initialized()
+    exp_config.pop("n")
     print("json=", json, bool(json), not json)
     if not json:
         return PlainTextResponse(yaml.dump(exp_config))

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -505,7 +505,7 @@ def reset(
         )
         raise ServerException(msg, status_code=403)
 
-    logger.error("Authorized reset, force=True. Removing data from database")
+    logger.warning("Authorized reset, force=True. Removing data from database")
     meta = _reset(timeout=timeout)
     assert meta["success"]
     return HTMLResponse(
@@ -576,7 +576,7 @@ def _reset(timeout: float = 5):
     files = [f.name for f in save_dir.glob("*")]
     logger.warning(f"dump_rdb in files? {'dump.rdb' in files}")
     if "dump.rdb" in files:
-        logger.error(f"Moving dump.rdb to dump-{now}.rdb")
+        logger.warning(f"Moving dump.rdb to dump-{now}.rdb")
         shutil.move(str(save_dir / "dump.rdb"), str(save_dir / f"dump-{now}.rdb"))
         files = [f.name for f in save_dir.glob("*")]
         logger.warning(f"after moving, dump_rdb in files? {'dump.rdb' in files}")

--- a/salmon/frontend/private.py
+++ b/salmon/frontend/private.py
@@ -548,6 +548,7 @@ def _reset(timeout: float = 5):
         logger.warning("    starting with clearing queries...")
         for ident in samplers:
             rj2.delete(f"alg-{ident}-queries")
+    httpx.post(f"http://localhost:8400/reset/")
 
     logger.warning("Trying to completely flush database...")
 

--- a/salmon/frontend/public.py
+++ b/salmon/frontend/public.py
@@ -77,7 +77,6 @@ async def _ensure_initialized():
         "targets",
         "samplers",
         "n",
-        "d",
         "sampling",
         "html"
     ]

--- a/salmon/frontend/public.py
+++ b/salmon/frontend/public.py
@@ -158,7 +158,7 @@ async def get_query(ident="") -> Dict[str, Union[int, str, float]]:
         q = manager.random_query(config["n"])
         score = -9999
 
-    return {"alg_ident": ident, "score": score, **q}
+    return {"sampler": ident, "score": score, **q}
 
 
 @app.post("/answer", tags=["public"])
@@ -180,7 +180,7 @@ async def process_answer(ans: manager.Answer):
         "loser": d["left"] if d["winner"] == d["right"] else d["right"],
     }
     d.update(_update)
-    ident = d["alg_ident"]
+    ident = d["sampler"]
     logger.warning(f"answer received: {d}")
     rj.jsonarrappend(f"alg-{ident}-answers", root, d)
         # on backend,  key = f"alg-{self.ident}-answers"

--- a/salmon/frontend/public.py
+++ b/salmon/frontend/public.py
@@ -142,7 +142,7 @@ async def get_query(ident="") -> Dict[str, Union[int, str, float]]:
         idx = np.random.choice(len(idents), p=probs)
         ident = idents[idx]
 
-    r = httpx.get(f"http://localhost:8400/query-{ident}")
+    r = httpx.get(f"http://localhost:8400/query/{ident}")
     if r.status_code == 200:
         logger.info(f"query r={r}")
         return r.json()

--- a/salmon/frontend/public.py
+++ b/salmon/frontend/public.py
@@ -19,7 +19,7 @@ from starlette_prometheus import PrometheusMiddleware, metrics
 
 from ..triplets import manager
 from ..utils import get_logger
-from .utils import ServerException, sha256, image_url
+from .utils import ServerException, image_url, sha256
 
 logger = get_logger(__name__)
 

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -209,7 +209,13 @@ class Config(BaseSettings):
     )
 
 
-    def update(self, user_config):
+    def parse(self, user_config):
+        self._update(user_config)
+        self = self.parse_obj(user_config)
+        self._validate()
+        return self
+
+    def _update(self, user_config):
         # Update user_config so when updated below, changes reflected.
         # (it's a plain dict, so it needs some help)
         if "sampling" in user_config and "common" in user_config["sampling"]:
@@ -217,9 +223,8 @@ class Config(BaseSettings):
             user_config["sampling"]["common"].update(self.dict()["sampling"]["common"])
 
         self._warn(user_config)
-        return self
 
-    def validate(self):
+    def _validate(self):
         if self.sampling.probs is None:
             # Sample each sampler equally
             n = len(self.samplers)

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -1,7 +1,7 @@
-from copy import deepcopy
-from textwrap import dedent
 import random
+from copy import deepcopy
 from datetime import datetime, timedelta
+from textwrap import dedent
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -89,7 +89,12 @@ class HTML(BaseSettings):
          css: ""
          max_queries: 50
          arrow_keys: true
+
+    Arbitrary keys are allowed in this class
+    (which might allow for customization on the HTML page).
     """
+    class Config:
+        extra = "allow"
 
     instructions: str = Field(
         "Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.",
@@ -219,8 +224,9 @@ class Config(BaseSettings):
         # Update user_config so when updated below, changes reflected.
         # (it's a plain dict, so it needs some help)
         if "sampling" in user_config and "common" in user_config["sampling"]:
-            s = self.dict()["sampling"]["common"]
-            user_config["sampling"]["common"].update(self.dict()["sampling"]["common"])
+            default_common = self.dict()["sampling"]["common"]
+            default_common.update(user_config["sampling"]["common"])
+            user_config["sampling"]["common"] = default_common
 
         self._warn(user_config)
 
@@ -315,15 +321,8 @@ def get_responses(answers: List[Dict[str, Any]], targets, start_time=0):
 
 def random_query(n: int) -> Dict[str, int]:
     rng = np.random.RandomState()
-    while True:
-        a, b, c = rng.choice(n, size=3)
-        if a != b and b != c and c != a:
-            break
-    return {
-        "head": int(a),
-        "left": int(b),
-        "right": int(c),
-    }
+    a, b, c = rng.choice(n, size=3, replace=False)
+    return {"head": int(a), "left": int(b), "right": int(c)}
 
 
 def _get_filename(html):

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -93,9 +93,14 @@ class HTML(BaseSettings):
     Arbitrary keys are allowed in this class
     (which might allow for customization on the HTML page).
     """
+
     class Config:
         extra = "allow"
 
+    title: str = Field(
+        "Similarity judgements",
+        description="The title of the HTML page (the text shown in the tab bar)",
+    )
     instructions: str = Field(
         "Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.",
         description="The instructions the user sees above each query.",
@@ -212,7 +217,6 @@ class Config(BaseSettings):
         description="""Settings to configure how more than two samplers are
         used. See :class:`~salmon.triplets.manager.Sampling` for more detail.""",
     )
-
 
     def parse(self, user_config):
         self._update(user_config)

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -22,7 +22,7 @@ class Answer(BaseModel):
     left: int
     right: int
     winner: int
-    alg_ident: str
+    sampler: str
     score: float = 0
     puid: str = ""
     response_time: float = -1

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -67,8 +67,8 @@ class Sampling(BaseSettings):
     samplers_per_user: int = Field(
         1,
         description="""The number of samplers to assign to each user. Setting
-        ``samplers_per_user==1`` means any user only sees queries generated
-        from one sampler, and ``sampler_per_user==0`` means the user sees a
+        ``samplers_per_user=1`` means any user only sees queries generated
+        from one sampler, and ``sampler_per_user=0`` means the user sees a
         new sampler every query"""
     )
 
@@ -117,7 +117,7 @@ class HTML(BaseSettings):
         50,
         description="""The number of queries that the user will answer before
         seeing the ``debrief`` message). Set ``max_queries=0`` or
-        ``max_queries=-1` to ask unlimited queries.""",
+        ``max_queries=-1`` to ask unlimited queries.""",
     )
     arrow_keys: bool = Field(
         True,

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -66,7 +66,7 @@ class Sampling(BaseSettings):
         probability.""",
     )
     samplers_per_user: int = Field(
-        1,
+        0,
         description="""The number of samplers to assign to each user. Setting
         ``samplers_per_user=1`` means any user only sees queries generated
         from one sampler, and ``sampler_per_user=0`` means the user sees a

--- a/salmon/triplets/manager.py
+++ b/salmon/triplets/manager.py
@@ -1,9 +1,10 @@
+from textwrap import dedent
 import random
 from datetime import datetime, timedelta
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, BaseSettings, Field
 
 
 class Answer(BaseModel):
@@ -25,6 +26,186 @@ class Answer(BaseModel):
     puid: str = ""
     response_time: float = -1
     network_latency: float = -1
+
+
+class Sampling(BaseSettings):
+    """
+    Settings to configure how more than two samplers are used.
+
+    These settings are used in the HTML but are not stylistic. The
+    exception is ``common``, which is passed to every ``sampler`` during
+    initialization and will likely be optional arguments for
+    :class:`~salmon.triplets.samplers.Adaptive`.
+
+    The default config represented as a YAML file:
+
+    .. code-block:: yaml
+
+       sampling:
+         common: {"d": 2}
+         probs: {"random": 100}
+         samplers_per_user: 1
+
+    """
+
+    common: Dict[str, Any] = Field(
+        {"d": 2},
+        description="""Arguments to pass to every sampler for initialization (likely
+        values for :class:`~salmon.triplets.samplers.Adaptive`; note that
+        values for ``n`` and ``ident`` are already specified). Any
+        values specified in this field will be overwritten by
+        sampler-specific arguments."""
+    )
+    probs: Optional[Dict[str, int]] = Field(
+        None,
+        description="""The percentage to sample each ``sampler`` when given the
+        opportunity (which depends on ``samplers_per_user``). The percentages
+        in this sampler must add up to 100.
+        If not specified (default), choose each sampler with equal
+        probability."""
+    )
+    samplers_per_user: int = Field(
+        1,
+        description="""The number of samplers to assign to each user. Setting
+        ``samplers_per_user==1`` means any user only sees queries generated
+        from one sampler, and ``sampler_per_user==0`` means the user sees a
+        new sampler every query"""
+    )
+
+
+class HTML(BaseSettings):
+    """
+    Stylistic settings to configure the HTML page.
+
+    The default configuration in YAML:
+
+    .. code-block:: yaml
+
+       html:
+         instructions: Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.
+         debrief: "<b>Thanks!</b> Please use the participant ID below."
+         skip_button: false
+         css: ""
+         max_queries: 50
+         arrow_keys: true
+    """
+
+    instructions: str = Field(
+        "Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.",
+        description="The instructions the user sees above each query.",
+    )
+    debrief: str = Field(
+        "<b>Thanks!</b> Please use the participant ID below.",
+        description=dedent(
+            """The message that the user sees after ``max_queries`` responses
+            have been completed. The participant ID (``puid``) is shown below
+            this message."""
+        ),
+    )
+    skip_button: bool = Field(
+        False,
+        description="""Wheter to show a button to skip queries. Most
+        useful when participants are instructed to skip queries only when the
+        know nothing about any object."""
+    )
+    css: str = Field(
+        "",
+        description="""CSS to be included the in the query page.  This CSS is
+        inserted just before the ``</style>`` tag in the HTML head.""",
+    )
+    max_queries: int = Field(
+        50,
+        description="""The number of queries that the user will answer before
+        seeing the ``debrief`` message). Set ``max_queries=0`` or
+        ``max_queries=-1` to ask unlimited queries.""",
+    )
+    arrow_keys: bool = Field(
+        True,
+        description="""Wheter to allow using the arrow keys as input.  Specifying
+        ``arrow_keys=True`` might allow bad input (though there is a delay of
+        200ms between queries)."""
+    )
+
+
+class Config(BaseSettings):
+    """
+    Customization of Salmon sampling and HTML.
+
+    This class is often specified through uploading an ``init.yaml`` file as
+    described in :ref:`yamlinitialization`. The default config is given below:
+
+    .. code-block:: yaml
+
+       samplers:
+         random: {class: Random}
+       sampling:
+         probs: {"random": 100}
+         sampler_per_user: 1
+         common:
+           d: 2
+       html:
+         instructions: Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.
+         debrief: <b>Thanks!</b> Please use the participant ID below.
+         skip_button: false
+         css: ""
+         arrow_keys: true
+       targets: ["vonn", "<i>Kildow</i>", "lindsey", "ted"]  # actually required
+
+    Some details on specific fields:
+
+    * The only required field is targets.
+
+        * ``targets`` is often specified with the upload of a ZIP file. See
+          :ref:`yaml_plus_zip` for more detail. If not, specify a list of strings (which
+          will be rendered as HTML).
+
+    * ``sampling`` is not relevant until ``samplers`` is customized.
+
+    Here's how to customize the config a bit with
+    a YAML file:
+
+    .. code-block:: yaml
+
+       samplers:
+         testing: {class: Random}
+         ARR: {}
+         Validation:
+           n_queries: 20
+       sampling:
+         probs: {"ARR": 40, "Validation": 20, "testing": 20}
+         common:
+           d: 3  # dimensions to embed to; passed to every sampler
+           random_state: 42  # argument to Adaptive
+           initial_batch_size: 128  # argument to Embedding
+       html:
+         instructions: Click buttons, <b><i>or else.</i></b>
+
+    Full documentation is below.
+
+    """
+
+    targets: Optional[Union[int, List[str]]] = Field(
+        None,
+        description="""A list of targets that will be rendered as HTML. If a ZIP file is
+            uploaded, this field is populated automatically.
+            See :ref:`yaml_plus_zip` for more detail.""",
+    )
+    html: HTML = Field(
+        HTML(),
+        description="""Stylistic settings to configure the HTML page.
+            See :class:`~salmon.triplets.manager.HTML` for more detail.""",
+    )
+    samplers: dict = Field(
+        {"random": {"class": "Random"}},
+        description="""Samplers to use, and their initialization parameters. See
+            above or ":ref:`adaptive-config`" for more detail on
+            customization, and :ref:`experiments` for experiments/benchmarks.""",
+    )
+    sampling: Sampling = Field(
+        Sampling(),
+        description="""Settings to configure how more than two samplers are
+        used. See :class:`~salmon.triplets.manager.Sampling` for more detail.""",
+    )
 
 
 def deserialize_query(serialized_query: str) -> Dict[str, int]:

--- a/salmon/triplets/samplers/__init__.py
+++ b/salmon/triplets/samplers/__init__.py
@@ -1,4 +1,4 @@
-from ._adaptive_runners import ARR, SRR, CKL, GNMDS, SOE, STE, TSTE, Adaptive
+from ._adaptive_runners import ARR, CKL, GNMDS, SOE, SRR, STE, TSTE, Adaptive
 from ._random_sampling import Random
 from ._round_robin import RoundRobin
 from ._test_runner import Test

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -69,6 +69,7 @@ class Adaptive(Sampler):
         """
         super().__init__(ident=ident)
 
+        logger.warning(f"Initializing Adaptive with n={n}, d={d}, R={R}")
         self.n = n
         self.d = d
         self.R = R

--- a/salmon/triplets/samplers/_adaptive_runners.py
+++ b/salmon/triplets/samplers/_adaptive_runners.py
@@ -11,10 +11,12 @@ import pandas as pd
 import torch.optim
 
 import salmon.triplets.samplers.adaptive as adaptive
-from ...backend.sampler import Sampler
-from salmon.triplets.samplers._random_sampling import _get_query as _random_query
+from salmon.triplets.samplers._random_sampling import \
+    _get_query as _random_query
 from salmon.triplets.samplers.adaptive import InfoGainScorer, UncertaintyScorer
 from salmon.utils import get_logger
+
+from ...backend.sampler import Sampler
 
 logger = get_logger(__name__)
 

--- a/salmon/triplets/samplers/_test_runner.py
+++ b/salmon/triplets/samplers/_test_runner.py
@@ -1,7 +1,7 @@
 from time import sleep
 
-from ._adaptive_runners import TSTE
 from ...backend.sampler import StopRunning
+from ._adaptive_runners import TSTE
 
 
 class Test(TSTE):

--- a/salmon/triplets/samplers/_test_runner.py
+++ b/salmon/triplets/samplers/_test_runner.py
@@ -1,9 +1,8 @@
 from time import sleep
 
-from ...backend.sampler import StopRunning
 from ._adaptive_runners import TSTE
 
 
 class Test(TSTE):
     def process_answers(self, ans):
-        raise StopRunning("Test error")
+        raise Exception("Test error")

--- a/salmon/triplets/samplers/_validation.py
+++ b/salmon/triplets/samplers/_validation.py
@@ -9,6 +9,9 @@ from ._round_robin import _get_query, _score_query, RoundRobin
 logger = logging.getLogger(__name__)
 
 
+def _random_query(n: int):
+    return np.random.choice(n, size=3, replace=False).tolist()
+
 class Validation(RoundRobin):
     """Ask about the same queries repeatedly"""
     def __init__(self, n, d=2, n_queries=20, queries=None, ident=""):
@@ -41,7 +44,13 @@ class Validation(RoundRobin):
         """
         self.n_queries = n_queries
         if queries is None:
-            queries = [np.random.choice(n, size=3, replace=False) for _ in range(n_queries)]
+            queries = []
+            while True:
+                q = _random_query(n)
+                if q not in queries:
+                    queries.append(q)
+                if len(queries) == n_queries:
+                    break
         idx = [i for query in queries for i in query]
         if n - 1 < max(idx):
             raise ValueError(

--- a/salmon/triplets/samplers/_validation.py
+++ b/salmon/triplets/samplers/_validation.py
@@ -4,8 +4,9 @@ import random
 import numpy as np
 
 from ...backend.sampler import Path
+from ._round_robin import RoundRobin, _get_query, _score_query
 from .utils import Answer, Query
-from ._round_robin import _get_query, _score_query, RoundRobin
+
 logger = logging.getLogger(__name__)
 
 

--- a/salmon/triplets/samplers/adaptive/_embed.py
+++ b/salmon/triplets/samplers/adaptive/_embed.py
@@ -1,6 +1,6 @@
 import itertools
 from copy import deepcopy
-from typing import List, Tuple, Union, Optional
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -1,5 +1,6 @@
-from salmon.triplets.manager import Config
 import pytest
+
+from salmon.triplets.manager import Config
 
 html_keys = ["debrief", "instructions", "max_queries", "skip_button"]
 

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -1,0 +1,110 @@
+from salmon.triplets.manager import Config
+import pytest
+
+html_keys = ["debrief", "instructions", "max_queries", "skip_button"]
+
+
+@pytest.mark.parametrize("key", html_keys)
+def test_old_html_keys(key):
+    c = Config()
+    with pytest.raises(ValueError, match="Move.*into the `html` key"):
+        c.update({key: "foo"})
+
+
+@pytest.mark.parametrize("key", html_keys)
+def test_html_propogates(key):
+    c = Config()
+
+    vals = {"max_queries": 50, "skip_button": True}
+    v = vals.get(key, "foobar")
+
+    user_config = {"html": {key: v}}
+
+    c.update(user_config)
+    c = c.parse_obj(user_config)
+    c.validate()
+
+    assert c.html.dict()[key] == v
+
+
+def test_defaults():
+    c = Config()
+
+    user_config = {"targets": [0, 1, 2, 3]}
+
+    c.update(user_config)
+    c = c.parse_obj(user_config)
+    c.validate()
+
+    assert c.dict() == {
+        "targets": ["0", "1", "2", "3"],
+        "html": {
+            "instructions": "Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.",
+            "debrief": "<b>Thanks!</b> Please use the participant ID below.",
+            "skip_button": False,
+            "css": "",
+            "max_queries": 50,
+            "arrow_keys": True,
+        },
+        "samplers": {"random": {"class": "Random"}},
+        "sampling": {
+            "common": {"d": 2},
+            "probs": {"random": 100},
+            "samplers_per_user": 1,
+        },
+    }
+
+
+def test_random_old_name_warns():
+    c = Config()
+    user_config = {"samplers": {"RandomSampling": {}}}
+    with pytest.raises(ValueError, match="renamed to `Random`"):
+        c.update(user_config)
+
+
+def test_wrong_probs():
+    c = Config()
+    user_config = {
+        "samplers": {"Random": {}, "ARR": {}},
+        "sampling": {"probs": {"Random": 50, "ARR": 40}},
+    }
+    c.update(user_config)
+    c = c.parse_obj(user_config)
+    with pytest.raises(ValueError, match="sampling.probs should add up to 100"):
+        c.validate()
+
+
+def test_wrong_keys():
+    c = Config()
+    user_config = {
+        "samplers": {"Random": {}, "ARR_v1": {}},
+        "sampling": {"probs": {"Random": 50, "ARR_v2": 50}},
+    }
+    c.update(user_config)
+    c = c.parse_obj(user_config)
+    with pytest.raises(ValueError, match="Keys in sampling.probs but not in samplers"):
+        c.validate()
+
+
+@pytest.mark.parametrize("v", [2, 3])
+def test_bad_samplers_per_keys(v):
+    c = Config()
+    user_config = {
+        "samplers": {"Random": {}, "ARR": {}},
+        "sampling": {"samplers_per_user": v},
+    }
+    c.update(user_config)
+    c = c.parse_obj(user_config)
+    with pytest.raises(NotImplementedError, match="Only samplers_per_user in {0, 1}"):
+        c.validate()
+
+
+def test_d_in_common_params():
+    c = Config()
+    user_config = {
+        "samplers": {"ARR": {}},
+        "sampling": {"common": {"foo": "bar"}},
+    }
+    c.update(user_config)
+    c = c.parse_obj(user_config)
+    assert "d" in c.sampling.common and c.sampling.common["d"] == 2

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -42,7 +42,7 @@ def test_defaults():
         "sampling": {
             "common": {"d": 2},
             "probs": {"random": 100},
-            "samplers_per_user": 1,
+            "samplers_per_user": 0,
         },
     }
 

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -8,7 +8,7 @@ html_keys = ["debrief", "instructions", "max_queries", "skip_button"]
 def test_old_html_keys(key):
     c = Config()
     with pytest.raises(ValueError, match="Move.*into the `html` key"):
-        c.update({key: "foo"})
+        c.parse({key: "foo"})
 
 
 @pytest.mark.parametrize("key", html_keys)
@@ -20,9 +20,7 @@ def test_html_propogates(key):
 
     user_config = {"html": {key: v}}
 
-    c.update(user_config)
-    c = c.parse_obj(user_config)
-    c.validate()
+    c = c.parse(user_config)
 
     assert c.html.dict()[key] == v
 
@@ -32,9 +30,7 @@ def test_defaults():
 
     user_config = {"targets": [0, 1, 2, 3]}
 
-    c.update(user_config)
-    c = c.parse_obj(user_config)
-    c.validate()
+    c = c.parse(user_config)
 
     assert c.dict() == {
         "targets": ["0", "1", "2", "3"],
@@ -59,7 +55,7 @@ def test_random_old_name_warns():
     c = Config()
     user_config = {"samplers": {"RandomSampling": {}}}
     with pytest.raises(ValueError, match="renamed to `Random`"):
-        c.update(user_config)
+        c.parse(user_config)
 
 
 def test_wrong_probs():
@@ -68,10 +64,8 @@ def test_wrong_probs():
         "samplers": {"Random": {}, "ARR": {}},
         "sampling": {"probs": {"Random": 50, "ARR": 40}},
     }
-    c.update(user_config)
-    c = c.parse_obj(user_config)
     with pytest.raises(ValueError, match="sampling.probs should add up to 100"):
-        c.validate()
+        c.parse(user_config)
 
 
 def test_wrong_keys():
@@ -80,10 +74,8 @@ def test_wrong_keys():
         "samplers": {"Random": {}, "ARR_v1": {}},
         "sampling": {"probs": {"Random": 50, "ARR_v2": 50}},
     }
-    c.update(user_config)
-    c = c.parse_obj(user_config)
     with pytest.raises(ValueError, match="Keys in sampling.probs but not in samplers"):
-        c.validate()
+        c.parse(user_config)
 
 
 @pytest.mark.parametrize("v", [2, 3])
@@ -93,10 +85,8 @@ def test_bad_samplers_per_keys(v):
         "samplers": {"Random": {}, "ARR": {}},
         "sampling": {"samplers_per_user": v},
     }
-    c.update(user_config)
-    c = c.parse_obj(user_config)
     with pytest.raises(NotImplementedError, match="Only samplers_per_user in {0, 1}"):
-        c.validate()
+        c.parse(user_config)
 
 
 def test_d_in_common_params():
@@ -105,6 +95,5 @@ def test_d_in_common_params():
         "samplers": {"ARR": {}},
         "sampling": {"common": {"foo": "bar"}},
     }
-    c.update(user_config)
-    c = c.parse_obj(user_config)
+    c = c.parse(user_config)
     assert "d" in c.sampling.common and c.sampling.common["d"] == 2

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -5,7 +5,7 @@ html_keys = ["debrief", "instructions", "max_queries", "skip_button"]
 
 
 @pytest.mark.parametrize("key", html_keys)
-def test_old_html_keys(key):
+def test_old_html_keys_warns(key):
     c = Config()
     with pytest.raises(ValueError, match="Move.*into the `html` key"):
         c.parse({key: "foo"})
@@ -95,3 +95,25 @@ def test_d_default_in_common_params():
     }
     c = Config().parse(user_config)
     assert c.sampling.common == {"d": 2, "foo": "bar"}
+
+
+def test_d_default_updates():
+    user_config = {
+        "samplers": {"ARR": {}, "TSTE": {}},
+        "sampling": {"common": {"d": 3}}
+    }
+    c = Config().parse(user_config)
+    assert c.sampling.common == {"d": 3}
+
+    user_config = {
+        "samplers": {"ARR": {}, "TSTE": {}},
+        "sampling": {"common": {"d": 3, "foo": "bar"}},
+    }
+    c = Config().parse(user_config)
+    assert c.sampling.common == {"d": 3, "foo": "bar"}
+
+
+def test_probs_default():
+    user_config = {"samplers": {"ARR": {}, "TSTE": {}}}
+    c = Config().parse(user_config)
+    assert c.sampling.probs == {"ARR": 50, "TSTE": 50}

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -31,6 +31,7 @@ def test_defaults():
         "targets": ["0", "1", "2", "3"],
         "html": {
             "instructions": "Please select the <i>comparison</i> item that is most similar to the <i>target</i> item.",
+            "title": "Similarity judgements",
             "debrief": "<b>Thanks!</b> Please use the participant ID below.",
             "skip_button": False,
             "css": "",
@@ -101,7 +102,7 @@ def test_d_default_in_common_params():
 def test_d_default_updates():
     user_config = {
         "samplers": {"ARR": {}, "TSTE": {}},
-        "sampling": {"common": {"d": 3}}
+        "sampling": {"common": {"d": 3}},
     }
     c = Config().parse(user_config)
     assert c.sampling.common == {"d": 3}

--- a/salmon/triplets/test_config.py
+++ b/salmon/triplets/test_config.py
@@ -13,24 +13,18 @@ def test_old_html_keys(key):
 
 @pytest.mark.parametrize("key", html_keys)
 def test_html_propogates(key):
-    c = Config()
-
     vals = {"max_queries": 50, "skip_button": True}
     v = vals.get(key, "foobar")
 
     user_config = {"html": {key: v}}
-
-    c = c.parse(user_config)
+    c = Config().parse(user_config)
 
     assert c.html.dict()[key] == v
 
 
 def test_defaults():
-    c = Config()
-
     user_config = {"targets": [0, 1, 2, 3]}
-
-    c = c.parse(user_config)
+    c = Config().parse(user_config)
 
     assert c.dict() == {
         "targets": ["0", "1", "2", "3"],
@@ -52,48 +46,52 @@ def test_defaults():
 
 
 def test_random_old_name_warns():
-    c = Config()
     user_config = {"samplers": {"RandomSampling": {}}}
+    c = Config()
     with pytest.raises(ValueError, match="renamed to `Random`"):
         c.parse(user_config)
 
 
 def test_wrong_probs():
-    c = Config()
     user_config = {
         "samplers": {"Random": {}, "ARR": {}},
         "sampling": {"probs": {"Random": 50, "ARR": 40}},
     }
+    c = Config()
     with pytest.raises(ValueError, match="sampling.probs should add up to 100"):
         c.parse(user_config)
 
 
 def test_wrong_keys():
-    c = Config()
     user_config = {
         "samplers": {"Random": {}, "ARR_v1": {}},
         "sampling": {"probs": {"Random": 50, "ARR_v2": 50}},
     }
+    c = Config()
     with pytest.raises(ValueError, match="Keys in sampling.probs but not in samplers"):
         c.parse(user_config)
 
 
-@pytest.mark.parametrize("v", [2, 3])
+@pytest.mark.parametrize("v", [0, 1, 2, 3])
 def test_bad_samplers_per_keys(v):
     c = Config()
     user_config = {
         "samplers": {"Random": {}, "ARR": {}},
         "sampling": {"samplers_per_user": v},
     }
-    with pytest.raises(NotImplementedError, match="Only samplers_per_user in {0, 1}"):
+    if v in [0, 1]:
         c.parse(user_config)
+    else:
+        with pytest.raises(
+            NotImplementedError, match="Only samplers_per_user in {0, 1}"
+        ):
+            c.parse(user_config)
 
 
-def test_d_in_common_params():
-    c = Config()
+def test_d_default_in_common_params():
     user_config = {
         "samplers": {"ARR": {}},
         "sampling": {"common": {"foo": "bar"}},
     }
-    c = c.parse(user_config)
-    assert "d" in c.sampling.common and c.sampling.common["d"] == 2
+    c = Config().parse(user_config)
+    assert c.sampling.common == {"d": 2, "foo": "bar"}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -46,7 +46,7 @@
         <li>Experiment config (partial):
           <ul>
             <li>Number of targets: {{config["n"]}}</li>
-            <li>Embedding dimension: {{config["d"]}}</li>
+            <li>Embedding dimension: {{config["sampling"]["common"]["d"]}}</li>
             <li>Samplers: {{samplers}}</li>
           </ul>
         </li>

--- a/templates/query_page.html
+++ b/templates/query_page.html
@@ -180,7 +180,7 @@ async function send(winner, id) {
           "response_time": response_time,
           "network_latency": latency,
           "score": score,
-          "alg_ident": ident,
+          "sampler": ident,
     };
     $.ajax({
       "url": "/answer",
@@ -229,7 +229,7 @@ function getquery(){
       right = data["right"];
       left = data["left"];
       score = data["score"];
-      ident = data["alg_ident"];
+      ident = data["sampler"];
       query = [head, left, right].join("-");
       if (prev_queries.includes(query)) {
         getquery();

--- a/templates/query_page.html
+++ b/templates/query_page.html
@@ -12,7 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
-<title>Salmon</title>
+<title>html['title']</title>
 
 {% for url in urls %}
 <link rel="prefetch" href={{url}}>

--- a/templates/query_page.html
+++ b/templates/query_page.html
@@ -12,7 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
-<title>html['title']</title>
+<title>{{html['title']}}</title>
 
 {% for url in urls %}
 <link rel="prefetch" href={{url}}>
@@ -66,7 +66,7 @@
   <div class="outline justify-content-center">
     <div class="row justify-content-center">
         <br>
-    <p> {{html['instructions'] | safe}} </p>
+        <p id="instructions">{{html['instructions'] | safe}}</p>
     </div>
     <!-- <hr> -->
     <div class="row justify-content-center" id="target-text">
@@ -83,7 +83,7 @@
       <div class="cell answer col col-lg-5 center cell answer" id="q-left"></div>
       <div class="cell answer col col-lg-5 center cell answer" id="q-right"></div>
     </div>
-    {% if skip_button %}
+    {% if html['skip_button'] %}
       <div class="d-flex align-items-end flex-column">
         <div id="skip-button" style="padding: 30px; padding-right: 60px;">
           <button type="button" class="btn btn-outline-secondary btn-sm" onclick="getquery()"
@@ -92,7 +92,6 @@
           >Skip this question</button>
         </div>
       </div>
-
     {% endif %}
 
   </div>
@@ -112,9 +111,7 @@
 <div class="modal fade" id="debriefModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content debrief">
-       <div class="modal-body">
-         {{ html['debrief'] | safe }}
-       </div>
+       <div class="modal-body" id="debrief">{{ html['debrief'] | safe }}</div>
        <div class="modal-body">
          Participant ID: <span id="puid">{{ puid }}</span>
       </div>

--- a/tests/data/active.yaml
+++ b/tests/data/active.yaml
@@ -1,6 +1,5 @@
 # filename: exp.yaml
 targets: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p]
-d: 2
 samplers:
   TSTE:
     alpha: 1.5
@@ -15,3 +14,6 @@ samplers:
   GNMDS:
     scorer: uncertainty
   ARR: {}
+sampling:
+  common:
+    d: 2

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -118,9 +118,9 @@ def test_active_queries_generated(server, sampler, logs):
                 sleep(1)
                 break
 
-            sleep(100e-3)
+            sleep(10e-3)
             if k % n == 0:
-                sleep(1)
+                sleep(0.1)
 
     d = server.get("/responses").json()
 

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -77,15 +77,6 @@ def test_active_bad_keys(server, logs):
             )
 
 
-# TODO: fix this failing test on github actions. Is it not running because
-@pytest.mark.xfail(
-    bool(os.environ.get("GITHUB_ACTIONS")),
-    reason="""passes locally w/ no backend errors; fails on GitHub actions
-              Tried to fix and failed; apparently the backend doesn't run in
-              GitHub Actions?""",
-    strict=True,
-    #  raises=LogError,  # something with posterior not being sized correctly?!
-)
 @pytest.mark.parametrize("sampler", ["ARR", "CKL"])
 def test_active_queries_generated(server, sampler, logs):
     # R=1 chosen because that determines when active sampling starts; this

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -41,7 +41,7 @@ def test_samplers_per_user(server, logs):
         r = server.get("/responses")
         d = r.json()
         df = pd.DataFrame(d)
-        algs = df.alg_ident.unique()
+        algs = df.sampler.unique()
         assert len(set(algs)) == 1
         _ = len(set(algs))
 
@@ -121,7 +121,7 @@ def test_active_queries_generated(server, sampler, logs):
     assert active_queries.sum()
     assert random_queries.sum()
 
-    samplers = set(df.alg_ident.unique())
+    samplers = set(df.sampler.unique())
     assert samplers == {sampler}
 
 
@@ -142,7 +142,7 @@ def test_active_basics(server, logs):
             q = server.get("/query").json()
 
             # Jerry rig this so this test isn't random (an algorithm is chosen at random)
-            q["alg_ident"] = samplers[k % len(samplers)]
+            q["sampler"] = samplers[k % len(samplers)]
             ans = random.choice([q["left"], q["right"]])
 
             ans = {"winner": ans, "puid": "foo", **q}
@@ -152,7 +152,7 @@ def test_active_basics(server, logs):
         d = r.json()
         df = pd.DataFrame(d)
         assert (df["score"] <= 1).all()
-        algs = df.alg_ident.unique()
+        algs = df.sampler.unique()
         assert set(algs) == {"TSTE", "ARR", "CKL", "tste2", "GNMDS"}
 
 

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -168,19 +168,3 @@ def test_round_robin(server, logs):
         assert {int(d) for d in diffs if not np.isnan(d)}.issubset({0, 1, 10})
         diffs = diffs.astype(int)
         assert (diffs == 0).sum() <= 2  # make sure zeros don't happen too often
-
-    # A traceback I got in this test once. I think I've fixed but am not sure;
-    # my tests pass, but I'm not certain this error is deterministic.
-    #
-    #  Traceback (most recent call last):
-    #    File "./salmon/backend/alg.py", line 92, in run
-    #      answers = self.get_answers(rj, clear=True)
-    #    File "./salmon/backend/alg.py", line 210, in get_answers
-    #      answers, success = pipe.execute()
-    #    File "/opt/conda/lib/python3.7/site-packages/redis/client.py", line 4019, in execute
-    #      return execute(conn, stack, raise_on_error)
-    #    File "/opt/conda/lib/python3.7/site-packages/redis/client.py", line 3943, in _execute_transaction
-    #      r = self.response_callbacks[command_name](r, **options)
-    #    File "/opt/conda/lib/python3.7/json/decoder.py", line 337, in decode
-    #      obj, end = self.raw_decode(s, idx=_w(s, 0).end())
-    #  TypeError: expected string or bytes-like object

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -17,7 +17,7 @@ from .utils import logs, server
 def test_active_wrong_proportion(server, logs):
     server.authorize()
     exp = {
-        "targets": 10,
+        "targets": 16,
         "sampling": {"probs": {"a1": 50, "a2": 40}},
         "samplers": {
             "a1": {"class": "Random"},
@@ -32,7 +32,7 @@ def test_active_wrong_proportion(server, logs):
 def test_active_bad_keys(server, logs):
     server.authorize()
     exp = {
-        "targets": 10,
+        "targets": 16,
         "sampling": {"probs": {"a1": 50, "a2": 40}},
         "samplers": {"a1": {"class": "Random"}},
     }
@@ -62,8 +62,9 @@ def test_active_basics(server, logs):
 
             # Jerry rig this so this test isn't random (an algorithm is chosen at random)
             q["alg_ident"] = samplers[k % len(samplers)]
+            ans = random.choice([q["left"], q["right"]])
 
-            ans = {"winner": random.choice([q["left"], q["right"]]), "puid": "foo", **q}
+            ans = {"winner": ans, "puid": "foo", **q}
             server.post("/answer", json=ans)
 
         r = server.get("/responses")

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -27,6 +27,7 @@ def test_active_wrong_proportion(server, logs):
     r = server.post("/init_exp", data={"exp": json.dumps(exp)}, error=True)
     assert r.status_code == 500
     assert "values in sampling.probs should add up to 100" in r.text
+    sleep(5)
 
 
 def test_active_bad_keys(server, logs):
@@ -42,6 +43,7 @@ def test_active_bad_keys(server, logs):
         x in r.text.lower()
         for x in ["sampling.probs keys", "are not the same as samplers keys"]
     )
+    sleep(5)
 
 
 def test_active_basics(server, logs):
@@ -73,6 +75,7 @@ def test_active_basics(server, logs):
         assert (df["score"] <= 1).all()
         algs = df.alg_ident.unique()
         assert set(algs) == {"TSTE", "ARR", "CKL", "tste2", "GNMDS"}
+    sleep(5)
 
 
 def test_samplers_per_user(server, logs):

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -100,12 +100,14 @@ def test_samplers_per_user(server, logs):
             q = server.get(f"/query?ident={ident}").json()
             ans = {"winner": random.choice([q["left"], q["right"]]), "puid": "foo", **q}
             server.post("/answer", json=ans)
+            sleep(0.1)
 
         r = server.get("/responses")
         d = r.json()
         df = pd.DataFrame(d)
         algs = df.alg_ident.unique()
         assert len(set(algs)) == 1
+        _ = len(set(algs))
 
 
 def test_round_robin(server, logs):

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -118,9 +118,9 @@ def test_active_queries_generated(server, sampler, logs):
                 sleep(1)
                 break
 
-            sleep(10e-3)
+            sleep(100e-3)
             if k % n == 0:
-                sleep(0.1)
+                sleep(1)
 
     d = server.get("/responses").json()
 

--- a/tests/test_active.py
+++ b/tests/test_active.py
@@ -76,13 +76,13 @@ def test_active_bad_keys(server, logs):
             )
 
 
-@pytest.mark.parametrize("sampler", ["ARR", "CKL", "TSTE", "STE", "GNMDS"])
-def test_active_chosen_queries_generated(server, sampler, logs):
+@pytest.mark.parametrize("sampler", ["ARR", "CKL"])
+def test_active_queries_generated(server, sampler, logs):
     # R=1 chosen because that determines when active sampling starts; this
     # test is designed to make sure no unexpected errors are thrown in
     # active portion (not that it generates a good embedding)
 
-    n = 7
+    n = 6
     config = {
         "targets": n,
         "samplers": {sampler: {}},
@@ -91,16 +91,18 @@ def test_active_chosen_queries_generated(server, sampler, logs):
     with logs:
         server.authorize()
         server.post("/init_exp", data={"exp": config})
-        for k in range(4 * n + 1):
+        for k in range(6 * n + 1):
             q = server.get("/query").json()
 
             ans = random.choice([q["left"], q["right"]])
             ans = {"winner": ans, "puid": "foo", **q}
+            print(q)
             server.post("/answer", json=ans)
+            c = 2  # for github actions
             if k % n == 0:
-                sleep(1)
-            if k == n:
-                sleep(2)
+                sleep(1 * c)
+            if k == n + 1:
+                sleep(2 * c)
         d = server.get("/responses").json()
 
     df = pd.DataFrame(d)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -56,7 +56,11 @@ def test_run_errors_logged(server, logs):
     # will reflect more of that.
     server.authorize()
     server.get("/init")
-    config = {"targets": list(range(10)), "d": 1, "samplers": {"ARR": {}}}
+    config = {
+        "targets": list(range(10)),
+        "sampling": {"common": {"d": 1}},
+        "samplers": {"ARR": {}},
+    }
     r = server.post("/init_exp", data={"exp": config})
     with pytest.raises(LogError):
         with logs:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -33,6 +33,7 @@ def test_backend_basics(server, logs):
             ans = {"winner": random.choice([q["left"], q["right"]]), "puid": puid, **q}
             ans["response_time"] = time() - _start
             server.post("/answer", data=ans)
+        sleep(5)
 
     print("Getting responses...")
     r = server.get("/responses")
@@ -69,14 +70,14 @@ def test_run_errors_logged(server, logs):
             server.authorize()
             server.get("/init")
             r = server.post("/init_exp", data={"exp": config})
-            for k in range(15):
+            for k in range(2):
                 q = server.get("/query").json()
                 winner = random.choice([q["left"], q["right"]])
                 ans = {"winner": winner, "puid": "", **q}
                 ans["left"] = 12
                 server.post("/answer", data=ans)
-                sleep(0.2 if k > 0 else 3)
-            sleep(5)
+                sleep(1e-3)
+            logs.delay = 7
 
 
 def test_backend_random_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -70,14 +70,14 @@ def test_run_errors_logged(server, logs):
             server.authorize()
             server.get("/init")
             r = server.post("/init_exp", data={"exp": config})
-            for k in range(2):
+            for k in range(10):
                 q = server.get("/query").json()
                 winner = random.choice([q["left"], q["right"]])
                 ans = {"winner": winner, "puid": "", **q}
                 ans["left"] = 12
                 server.post("/answer", data=ans)
-                sleep(1e-3)
-            logs.delay = 7
+                sleep(2 if k == 3 else 1)
+            sleep(5)
 
 
 def test_backend_random_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -76,6 +76,7 @@ def test_run_errors_logged(server, logs):
                 ans["left"] = 12
                 server.post("/answer", data=ans)
                 sleep(0.2 if k > 0 else 3)
+            sleep(5)
 
 
 def test_backend_random_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -45,15 +45,13 @@ def test_backend_basics(server, logs):
 def test_init_errors_propogate(server, logs):
     exp = Path(__file__).parent / "data" / "exp-active-bad.yaml"
 
-    with pytest.raises(LogError):
-        with logs:
-            server.authorize()
-            server.get("/init")
-            r = server.post("/init_exp", data={"exp": exp.read_text()}, error=True)
-            assert r.status_code == 500
-            assert (
-                "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
-            )
+    server.authorize()
+    server.get("/init")
+    r = server.post("/init_exp", data={"exp": exp.read_text()}, error=True)
+    assert r.status_code == 500
+    assert (
+        "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
+    )
 
 
 def test_run_errors_logged(server, logs):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -17,14 +17,14 @@ from .utils import LogError, logs, server
 
 def test_backend_basics(server, logs):
     exp = Path(__file__).parent / "data" / "round-robin.yaml"
-    server.authorize()
-    server.post("/init_exp", data={"exp": exp.read_text()})
     exp_config = yaml.safe_load(exp.read_text())
 
     # ran into a bug that happened with len(samplers) > 1
     assert len(exp_config["samplers"]) == 1
     puid = "puid-foo"
     with logs:
+        server.authorize()
+        server.post("/init_exp", data={"exp": exp.read_text()})
         for k in range(30):
             _start = time()
             q = server.get("/query").json()
@@ -41,29 +41,32 @@ def test_backend_basics(server, logs):
     assert len(df) == 30
 
 
-def test_init_errors_propogate(server):
-    server.authorize()
-    server.get("/init")
+def test_init_errors_propogate(server, logs):
     exp = Path(__file__).parent / "data" / "exp-active-bad.yaml"
-    r = server.post("/init_exp", data={"exp": exp.read_text()}, error=True)
-    assert r.status_code == 500
-    assert "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
+
+    with pytest.raises(LogError):
+        with logs:
+            server.authorize()
+            server.get("/init")
+            r = server.post("/init_exp", data={"exp": exp.read_text()}, error=True)
+            assert r.status_code == 500
+            assert "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
 
 
 def test_run_errors_logged(server, logs):
     # This test is only designed to make sure errors are raised during pytest
     # it's not designed to make sure errors have much detail; the docker logs
     # will reflect more of that.
-    server.authorize()
-    server.get("/init")
     config = {
         "targets": list(range(10)),
         "sampling": {"common": {"d": 1}},
         "samplers": {"ARR": {}},
     }
-    r = server.post("/init_exp", data={"exp": config})
     with pytest.raises(LogError):
         with logs:
+            server.authorize()
+            server.get("/init")
+            r = server.post("/init_exp", data={"exp": config})
             for k in range(10):
                 q = server.get("/query").json()
                 winner = random.choice([q["left"], q["right"]])
@@ -71,9 +74,10 @@ def test_run_errors_logged(server, logs):
                 ans["left"] = 12
                 sleep(1)
                 server.post("/answer", data=ans)
+            server.reset()
         server.reset()
     server.reset()
-    sleep(5)
+    sleep(2)
 
 
 def test_backend_random_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -50,7 +50,9 @@ def test_init_errors_propogate(server, logs):
             server.get("/init")
             r = server.post("/init_exp", data={"exp": exp.read_text()}, error=True)
             assert r.status_code == 500
-            assert "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
+            assert (
+                "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
+            )
 
 
 def test_run_errors_logged(server, logs):
@@ -72,12 +74,9 @@ def test_run_errors_logged(server, logs):
                 winner = random.choice([q["left"], q["right"]])
                 ans = {"winner": winner, "puid": "", **q}
                 ans["left"] = 12
-                sleep(1)
+                sleep(0.1)
                 server.post("/answer", data=ans)
-            server.reset()
-        server.reset()
-    server.reset()
-    sleep(2)
+            sleep(7)
 
 
 def test_backend_random_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -69,14 +69,13 @@ def test_run_errors_logged(server, logs):
             server.authorize()
             server.get("/init")
             r = server.post("/init_exp", data={"exp": config})
-            for k in range(10):
+            for k in range(15):
                 q = server.get("/query").json()
                 winner = random.choice([q["left"], q["right"]])
                 ans = {"winner": winner, "puid": "", **q}
                 ans["left"] = 12
-                sleep(0.1)
                 server.post("/answer", data=ans)
-            sleep(7)
+                sleep(0.2 if k > 0 else 3)
 
 
 def test_backend_random_state():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -71,7 +71,7 @@ def test_run_errors_logged(server, logs):
                 ans["left"] = 12
                 sleep(1)
                 server.post("/answer", data=ans)
-    sleep(5)
+        server.reset()
     server.reset()
     sleep(5)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -19,7 +19,6 @@ def test_backend_basics(server, logs):
     exp = Path(__file__).parent / "data" / "round-robin.yaml"
     exp_config = yaml.safe_load(exp.read_text())
 
-    # ran into a bug that happened with len(samplers) > 1
     assert len(exp_config["samplers"]) == 1
     puid = "puid-foo"
     with logs:
@@ -42,16 +41,14 @@ def test_backend_basics(server, logs):
     assert len(df) == 30
 
 
-def test_init_errors_propogate(server, logs):
+def test_init_errors_propogate(server):
     exp = Path(__file__).parent / "data" / "exp-active-bad.yaml"
 
     server.authorize()
     server.get("/init")
     r = server.post("/init_exp", data={"exp": exp.read_text()}, error=True)
     assert r.status_code == 500
-    assert (
-        "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
-    )
+    assert "module 'salmon.triplets.samplers' has no attribute 'FooBar'" in r.text
 
 
 def test_run_errors_logged(server, logs):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -71,8 +71,9 @@ def test_run_errors_logged(server, logs):
                 ans["left"] = 12
                 sleep(1)
                 server.post("/answer", data=ans)
-
+    sleep(5)
     server.reset()
+    sleep(5)
 
 
 def test_backend_random_state():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,7 +77,7 @@ def test_basics(server, logs):
         "response_time",
         "network_latency",
         "datetime_received",
-        "alg_ident",
+        "sampler",
         "score",
     }
     assert (df["winner"] != df["loser"]).all()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pytest
 import yaml
 
-from .utils import logs, server
+from .utils import logs, server, LogError
 
 
 def test_basics(server, logs):
@@ -360,8 +360,10 @@ def test_validation_sampling(server, logs):
 
 
 def test_random_error(server, logs):
-    server.authorize()
     n_val = 5
     exp = {"targets": [0, 1, 2, 3, 4, 5], "samplers": {"RandomSampling": {}, "ARR": {}}}
-    r = server.post("/init_exp", data={"exp": exp}, status_code=500)
-    assert "The sampler `RandomSampling` has been renamed to `Random`" in r.text
+
+    with pytest.raises(LogError), logs:
+        server.authorize()
+        r = server.post("/init_exp", data={"exp": exp}, status_code=500)
+        assert "The sampler `RandomSampling` has been renamed to `Random`" in r.text

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -268,12 +268,12 @@ def test_get_config(server):
 
 def test_config_defaults(server):
     server.authorize()
-    html = {"instructions": "foo", "debrief": "bar", "max_queries": 42, "custom": "foo"}
+    html = {"instructions": "foo", "debrief": "bar", "max_queries": 42, "custom_tag": "foo"}
     exp = {"targets": 10, "html": html}
     server.post("/init_exp", data={"exp": exp})
 
     rendered = server.get("/config").json()
-    assert "custom" in rendered["html"] and rendered["html"]["custom"] == "foo"
+    assert "custom_tag" in rendered["html"] and rendered["html"]["custom_tag"] == "foo"
     assert rendered["html"]["instructions"] == "foo"
     assert rendered["html"]["debrief"] == "bar"
     assert rendered["html"]["max_queries"] == 42

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -42,7 +42,7 @@ def test_basics(server, logs):
             q = server.get("/query").json()
             ans = {"winner": random.choice([q["left"], q["right"]]), "puid": puid, **q}
             answers.append(ans)
-            sleep(1e-3)
+            sleep(100e-3)
             ans["response_time"] = time() - _start
             server.post("/answer", data=ans)
 
@@ -126,6 +126,7 @@ def test_no_repeats(server):
         q = server.get("/query").json()
         ans = {"winner": random.choice([q["left"], q["right"]]), "puid": "foo", **q}
         server.post("/answer", data=ans)
+        sleep(10e-3)
 
     r = server.get("/responses")
     df = pd.DataFrame(r.json())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -35,13 +35,14 @@ def test_basics(server, logs):
     puid = "puid-foo"
     answers = []
     print("Starting loop...")
+    n_ans = 40
     with logs:
-        for k in range(70):
+        for k in range(n_ans):
             _start = time()
             q = server.get("/query").json()
             ans = {"winner": random.choice([q["left"], q["right"]]), "puid": puid, **q}
             answers.append(ans)
-            sleep(10e-3)
+            sleep(1e-3)
             ans["response_time"] = time() - _start
             server.post("/answer", data=ans)
 
@@ -100,7 +101,7 @@ def test_basics(server, logs):
     assert r.status_code == 200
     assert "exception" not in r.text
     df = pd.DataFrame(r.json())
-    assert len(df) == 70
+    assert len(df) == n_ans
 
     r = server.get("/dashboard")
     assert r.status_code == 200
@@ -325,7 +326,7 @@ def test_auth_repeated_entries(server):
 
 
 def test_validation_sampling(server, logs):
-    n_val = 3
+    n_val = 4
     exp = {
         "targets": list(range(10)),
         "samplers": {"Validation": {"n_queries": n_val}},
@@ -333,7 +334,7 @@ def test_validation_sampling(server, logs):
     data = []
     puid = "adsfjkl4awjklra"
 
-    n_repeat = 4
+    n_repeat = 3
     with logs:
         server.authorize()
         server.post("/init_exp", data={"exp": exp})
@@ -345,11 +346,11 @@ def test_validation_sampling(server, logs):
             data.append(ans)
             sleep(0.2)
 
-        sleep(2)
+        sleep(3)
         r = server.get("/responses")
 
     queries = [(q["head"], (q["left"], q["right"])) for q in r.json()]
-    uniq_queries = [((h, min(c), max(c))) for h, c in queries]
+    uniq_queries = [(h, min(c), max(c)) for h, c in queries]
     assert len(set(uniq_queries)) == n_val
 
     order = [hash(q) for q in queries]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -327,7 +327,7 @@ def test_auth_repeated_entries(server):
 
 
 def test_validation_sampling(server, logs):
-    n_val = 4
+    n_val = 3
     exp = {
         "targets": list(range(10)),
         "samplers": {"Validation": {"n_queries": n_val}},
@@ -350,10 +350,12 @@ def test_validation_sampling(server, logs):
         sleep(3)
         r = server.get("/responses")
 
+    # Test the number of unique queries is specified by n_val
     queries = [(q["head"], (q["left"], q["right"])) for q in r.json()]
     uniq_queries = [(h, min(c), max(c)) for h, c in queries]
     assert len(set(uniq_queries)) == n_val
 
+    # Test the order gets shuffled every iteration
     order = [hash(q) for q in queries]
     round_orders = [order[k * n_val : (k + 1) * n_val] for k in range(n_repeat)]
     for round_order in round_orders:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -27,7 +27,12 @@ def test_basics(server, logs):
     r = server.delete("/reset?force=1", timeout=20)
     assert r.json() == {"success": True}
     server.delete("/reset", status_code=401, auth=("foo", "bar"))
+
+    r = server.authorize()
+    assert r.status_code == 200
     r = server.delete("/reset?force=1", timeout=20)
+    server.authorize()
+
     assert r.json() == {"success": True}
     server.get("/init")
     exp = Path(__file__).parent / "data" / "exp.yaml"
@@ -159,6 +164,8 @@ def test_saves_state(server):
     dump = Path(__file__).absolute().parent.parent / "out" / "dump.rdb"
     assert not dump.exists()
     exp = Path(__file__).parent / "data" / "exp.yaml"
+
+    server.authorize()
     server.post("/init_exp", data={"exp": exp.read_text()})
     for k in range(10):
         q = server.get("/query").json()
@@ -217,6 +224,7 @@ def test_logs(server, logs):
     assert not dump.exists()
     exp = Path(__file__).parent / "data" / "exp.yaml"
     server.delete("/reset?force=1", timeout=20)
+    server.authorize()
     server.post("/init_exp", data={"exp": exp.read_text()})
     data = []
     puid = "adsfjkl4awjklra"
@@ -311,6 +319,7 @@ def test_no_init_twice(server, logs):
     server.delete("/reset", status_code=403, timeout=20)
     server.delete("/reset?force=1", timeout=20)
 
+    server.authorize()
     server.post("/init_exp", data={"exp": exp.read_text()}, timeout=20)
     query = server.get("/query")
     assert query
@@ -365,6 +374,7 @@ def test_defaults_acceptable_config(server):
     config = server.get("/config").json()
 
     server.reset()
+    server.authorize()
     r = server.post("/init_exp", data={"exp": config})
     assert r.status_code == 200
     config2 = server.get("/config").json()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -325,8 +325,6 @@ def test_auth_repeated_entries(server):
     assert "maximum number of users" in r.text.lower()
 
 
-
-
 def test_random_error(server, logs):
     n_val = 5
     exp = {"targets": [0, 1, 2, 3, 4, 5], "samplers": {"RandomSampling": {}, "ARR": {}}}
@@ -358,3 +356,16 @@ def test_html_defaults_rendered(server):
         "document.onkeydown = function checkKey(e) {" in rendered
         and "e.keyCode == '37') { // left arrow" in rendered
     )
+
+
+def test_defaults_acceptable_config(server):
+    server.authorize()
+    r = server.post("/init_exp", data={"exp": {"targets": 10}})
+    assert r.status_code == 200
+    config = server.get("/config").json()
+
+    server.reset()
+    r = server.post("/init_exp", data={"exp": config})
+    assert r.status_code == 200
+    config2 = server.get("/config").json()
+    assert config == config2

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -110,6 +110,9 @@ def test_basics(server, logs):
 
     r = server.get("/dashboard")
     assert r.status_code == 200
+    assert "Embedding dimension: 2" in r.text
+    assert "Number of targets: 6" in r.text
+    assert "Samplers: [&#39;random&#39;]" in r.text  # &#39; is HTML for the apostrophe
 
 
 def test_bad_file_upload(server):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -325,18 +325,18 @@ def test_auth_repeated_entries(server):
 
 
 def test_validation_sampling(server, logs):
-    server.authorize()
     n_val = 3
     exp = {
         "targets": list(range(10)),
         "samplers": {"Validation": {"n_queries": n_val}},
     }
-    server.post("/init_exp", data={"exp": exp})
     data = []
     puid = "adsfjkl4awjklra"
 
     n_repeat = 4
     with logs:
+        server.authorize()
+        server.post("/init_exp", data={"exp": exp})
         for k in range(n_repeat * n_val):
             q = server.get("/query").json()
             _ans = random.choice([q["left"], q["right"]])

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pytest
 import yaml
 
-from .utils import logs, server, LogError
+from .utils import LogError, logs, server
 
 
 def test_basics(server, logs):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -343,9 +343,9 @@ def test_validation_sampling(server, logs):
             ans = {"winner": _ans, "puid": k, **q}
             server.post("/answer", data=ans)
             data.append(ans)
-            sleep(0.1)
+            sleep(0.2)
 
-        sleep(1)
+        sleep(2)
         r = server.get("/responses")
 
     queries = [(q["head"], (q["left"], q["right"])) for q in r.json()]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,13 +9,13 @@ Non-goal: testing to make sure that the backend runs without errors.
 
 """
 import random
-from time import sleep
 from pathlib import Path
+from time import sleep
 from zipfile import ZipFile
 
 import pytest
 
-from .utils import server, logs
+from .utils import server
 
 EG_DIR = Path(__file__).parent.parent / "examples"
 SUBDIRS = [

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -11,6 +11,7 @@ Non-goal: testing to make sure that the backend runs without errors.
 import random
 from pathlib import Path
 from zipfile import ZipFile
+import yaml
 
 import pytest
 
@@ -21,6 +22,16 @@ SUBDIRS = [
     f.name for f in EG_DIR.iterdir() if f.is_dir() and f.name[0] not in ["_", "."]
 ]
 YAMLS = [f.name for f in EG_DIR.glob("*.yaml")]
+
+
+def test_defaults_config(server):
+    server.authorize()
+    targets = ["actually", "required", "with", "zip", "or", "yaml"]
+    r = server.post("/init_exp", data={"exp": {"targets": targets}})
+    assert r.status_code == 200
+    defaults = server.get("/config").json()
+    rendered = yaml.load((EG_DIR / "default.yaml").open())
+    assert defaults == rendered
 
 
 def _test_upload(exp: Path, target_zip: Path = None, server=None):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,13 @@
+"""
+This file tests to make sure that all the examples launch without errors.
+
+Goal: ensure the YAML files aren't out of date).
+Goal: ensure the examples at least launch and run.
+Non-goal: testing to make sure that the backend runs without errors.
+    (we know backend init errors propogate because of
+    test_backend.test_init_errors_propogate)
+
+"""
 import random
 from time import sleep
 from pathlib import Path
@@ -48,19 +58,17 @@ def _test_example(exp, target_zip=None, server=None):
 
 
 @pytest.mark.parametrize("fname", YAMLS)
-def test_basic_examples(fname: str, server, logs):
-    with logs:
-        server.authorize()
-        success = _test_example(EG_DIR / fname, server=server)
+def test_basic_examples(fname: str, server):
+    server.authorize()
+    success = _test_example(EG_DIR / fname, server=server)
     assert success
 
 
 @pytest.mark.parametrize("eg_dir", SUBDIRS)
-def test_directory_examples(eg_dir: str, server, logs):
+def test_directory_examples(eg_dir: str, server):
     _eg_dir = EG_DIR / eg_dir
-    with logs:
-        server.authorize()
-        for exp in _eg_dir.glob("*.yaml"):
-            for target_zip in _eg_dir.glob("*.zip"):
-                success = _test_example(exp, target_zip, server)
-                assert success
+    server.authorize()
+    for exp in _eg_dir.glob("*.yaml"):
+        for target_zip in _eg_dir.glob("*.zip"):
+            success = _test_example(exp, target_zip, server)
+            assert success

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -10,7 +10,6 @@ Non-goal: testing to make sure that the backend runs without errors.
 """
 import random
 from pathlib import Path
-from time import sleep
 from zipfile import ZipFile
 
 import pytest

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,6 +1,5 @@
 import random
 from pathlib import Path
-from time import sleep
 from zipfile import ZipFile
 
 import pytest
@@ -30,6 +29,7 @@ def _test_upload(exp: Path, target_zip: Path = None, server=None):
     r = server.post("/init_exp", data={"exp": exp.read_text()}, timeout=60, **kwargs)
     return r.status_code == 200
 
+
 def _test_example(exp, target_zip=None, server=None):
     assert server is not None
     success = _test_upload(exp, target_zip, server)
@@ -42,9 +42,9 @@ def _test_example(exp, target_zip=None, server=None):
         query["winner"] = random.choice([query["left"], query["right"]])
         r = server.post("/answer", data=query)
         assert r.status_code == 200
-    r = server.delete("/reset?force=1", timeout=20)
-    assert r.json() == {"success": True}
+    server.reset()
     return True
+
 
 @pytest.mark.parametrize("fname", YAMLS)
 def test_basic_examples(fname: str, server):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,10 +1,11 @@
 import random
+from time import sleep
 from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
 
-from .utils import server
+from .utils import server, logs
 
 EG_DIR = Path(__file__).parent.parent / "examples"
 SUBDIRS = [
@@ -47,17 +48,19 @@ def _test_example(exp, target_zip=None, server=None):
 
 
 @pytest.mark.parametrize("fname", YAMLS)
-def test_basic_examples(fname: str, server):
-    server.authorize()
-    success = _test_example(EG_DIR / fname, server=server)
+def test_basic_examples(fname: str, server, logs):
+    with logs:
+        server.authorize()
+        success = _test_example(EG_DIR / fname, server=server)
     assert success
 
 
 @pytest.mark.parametrize("eg_dir", SUBDIRS)
-def test_directory_examples(eg_dir: str, server):
-    server.authorize()
+def test_directory_examples(eg_dir: str, server, logs):
     _eg_dir = EG_DIR / eg_dir
-    for exp in _eg_dir.glob("*.yaml"):
-        for target_zip in _eg_dir.glob("*.zip"):
-            success = _test_example(exp, target_zip, server)
-            assert success
+    with logs:
+        server.authorize()
+        for exp in _eg_dir.glob("*.yaml"):
+            for target_zip in _eg_dir.glob("*.zip"):
+                success = _test_example(exp, target_zip, server)
+                assert success

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -98,3 +98,9 @@ def test_offline_init():
     assert np.allclose(est.embedding_, em)
     est.partial_fit(X)
     assert not np.allclose(est.embedding_, em), "Embedding didn't change"
+
+
+if __name__ == "__main__":
+    test_offline_init()
+    test_offline_embedding_random_state()
+    test_offline_embedding()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -38,12 +38,12 @@ def test_validation_sampling(server, logs):
         Q.append(ans)
         server.post("/answer", data=ans)
         data.append(ans)
-        sleep(0.10)
+        sleep(0.20)
 
     # Test the number of unique queries is specified by n_val
     queries = [(q["head"], (q["left"], q["right"])) for q in Q]
     uniq_queries = [(h, min(c), max(c)) for h, c in queries]
-    assert len(set(uniq_queries)) == n_val
+    assert len(set(uniq_queries)) == n_val, set(uniq_queries)
 
     # Test the order gets shuffled every iteration
     order = [hash(q) for q in queries]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,12 +1,16 @@
+import pytest
+
 from .utils import LogError, logs, server
 
 
-def test_init_w_queries_valid_idx(server):
-    server.authorize()
-    server.get("/init")
+def test_init_w_queries_valid_idx(server, logs):
     samplers = {"Validation": {"queries": [[0, 1, 4], [0, 1, 5]]}}
     exp = {"targets": [0, 1, 2, 3], "samplers": samplers}
-    r = server.post("/init_exp", data={"exp": exp}, error=True)
-    assert r.status_code == 500
-    assert "the index 5 is included" in r.text.lower()
-    assert "the n=4 targets" in r.text.lower()
+
+    with pytest.raises(LogError), logs:
+        server.authorize()
+        server.get("/init")
+        r = server.post("/init_exp", data={"exp": exp}, error=True)
+        assert r.status_code == 500
+        assert "the index 5 is included" in r.text.lower()
+        assert "the n=4 targets" in r.text.lower()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,5 @@
+import random
+from time import sleep
 import pytest
 
 from .utils import LogError, logs, server
@@ -14,3 +16,40 @@ def test_init_w_queries_valid_idx(server, logs):
         assert r.status_code == 500
         assert "the index 5 is included" in r.text.lower()
         assert "the n=4 targets" in r.text.lower()
+
+
+def test_validation_sampling(server, logs):
+    n_val = 4
+    exp = {
+        "targets": list(range(10)),
+        "samplers": {"Validation": {"n_queries": n_val}},
+    }
+    data = []
+    puid = "adsfjkl4awjklra"
+
+    n_repeat = 3
+    server.authorize()
+    server.post("/init_exp", data={"exp": exp})
+    for k in range(n_repeat * n_val):
+        q = server.get("/query").json()
+        _ans = random.choice([q["left"], q["right"]])
+        ans = {"winner": _ans, "puid": k, **q}
+        server.post("/answer", data=ans)
+        data.append(ans)
+        sleep(0.20)
+
+    sleep(1)
+    r = server.get("/responses")
+
+    # Test the number of unique queries is specified by n_val
+    queries = [(q["head"], (q["left"], q["right"])) for q in r.json()]
+    uniq_queries = [(h, min(c), max(c)) for h, c in queries]
+    assert len(set(uniq_queries)) == n_val
+
+    # Test the order gets shuffled every iteration
+    order = [hash(q) for q in queries]
+    round_orders = [order[k * n_val : (k + 1) * n_val] for k in range(n_repeat)]
+    for round_order in round_orders:
+        assert len(set(round_order)) == n_val
+    same_order = [round_orders[0] != order for order in round_orders[1:]]
+    assert sum(same_order) in [len(same_order), len(same_order) - 1]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -30,19 +30,18 @@ def test_validation_sampling(server, logs):
     n_repeat = 3
     server.authorize()
     server.post("/init_exp", data={"exp": exp})
+    Q = []
     for k in range(n_repeat * n_val):
         q = server.get("/query").json()
         _ans = random.choice([q["left"], q["right"]])
         ans = {"winner": _ans, "puid": k, **q}
+        Q.append(ans)
         server.post("/answer", data=ans)
         data.append(ans)
-        sleep(0.20)
-
-    sleep(1)
-    r = server.get("/responses")
+        sleep(0.10)
 
     # Test the number of unique queries is specified by n_val
-    queries = [(q["head"], (q["left"], q["right"])) for q in r.json()]
+    queries = [(q["head"], (q["left"], q["right"])) for q in Q]
     uniq_queries = [(h, min(c), max(c)) for h, c in queries]
     assert len(set(uniq_queries)) == n_val
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -35,6 +35,7 @@ def test_validation_sampling(server, logs):
         q = server.get("/query").json()
         _ans = random.choice([q["left"], q["right"]])
         ans = {"winner": _ans, "puid": k, **q}
+        print([ans[k] for k in ["head", "left", "right"]])
         Q.append(ans)
         server.post("/answer", data=ans)
         data.append(ans)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,9 @@
 import json
 from logging import getLogger
 from pathlib import Path
+from time import sleep
 from typing import Tuple
 from warnings import warn
-from time import sleep
 
 import httpx as requests
 import numpy as np

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -108,7 +108,7 @@ def _reset(server):
 def server():
     server = Server("http://127.0.0.1:8421")
     server.authorize()
-    server = _reset(server)
+    #  server = _reset(server)
     yield server
     server = _reset(server)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,7 +36,8 @@ class Server:
         logger.info(f"Getting {endpoint}")
         r = requests.get(self.url + endpoint, **kwargs)
         logger.info("done")
-        assert r.status_code == status_code, (r.status_code, status_code, r.text)
+        if status_code:
+            assert r.status_code == status_code, (r.status_code, status_code, r.text)
         return r
 
     def reset(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,7 +113,6 @@ class Logs:
         self.warn = True
 
     def __enter__(self):
-        # Clear logs
         _clear_logs()
 
     def __exit__(self, exc_type, exc_value, traceback):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -99,7 +99,6 @@ def _reset(server):
         dump.unlink()
     assert not dump.exists()
 
-    # to double-check; dump might have been saved
     server.reset()
     return server
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,19 +88,29 @@ def _clear_logs(log=None):
             _clear_logs(log=log)
 
 
+def _reset(server):
+    server.reset()
+
+    # Delete files
+    _clear_logs()
+    OUT = Path(__file__).absolute().parent.parent / "out"
+    dump = OUT / "dump.rdb"
+    if dump.exists():
+        dump.unlink()
+    assert not dump.exists()
+
+    # to double-check; dump might have been saved
+    server.reset()
+    return server
+
+
 @pytest.fixture()
 def server():
     server = Server("http://127.0.0.1:8421")
     server.authorize()
-
-    server.reset()
-    _clear_logs()
+    server = _reset(server)
     yield server
-    dump = Path(__file__).absolute().parent.parent / "out" / "dump.rdb"
-    if dump.exists():
-        dump.unlink()
-    server.reset()
-    _clear_logs()
+    server = _reset(server)
 
 
 class LogError(Exception):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,7 +113,7 @@ class Logs:
         self.log_dir = root_dir / "out"
         self.catch = True
         self.warn = True
-        self.delay = 2
+        self.delay = 0.5  # for files to finish flushing
 
     def __enter__(self):
         _clear_logs()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -74,6 +74,7 @@ class Server:
         r = self.post(f"/create_user/{username}/{password}", error=True)
         assert r.status_code in {200, 403}
         self._authorized = True
+        return r
 
 
 def _clear_logs(log=None):
@@ -89,6 +90,7 @@ def _clear_logs(log=None):
 
 
 def _reset(server):
+    server.authorize()
     server.reset()
 
     # Delete files
@@ -99,7 +101,8 @@ def _reset(server):
         dump.unlink()
     assert not dump.exists()
 
-    server.reset()
+    #  server.authorize()
+    #  server.reset()
     return server
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import Tuple
 from warnings import warn
+from time import sleep
 
 import httpx as requests
 import numpy as np
@@ -112,6 +113,7 @@ class Logs:
         self.log_dir = root_dir / "out"
         self.catch = True
         self.warn = True
+        self.delay = 2
 
     def __enter__(self):
         _clear_logs()
@@ -119,6 +121,7 @@ class Logs:
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type is not None:
             raise exc_type(exc_value)
+        sleep(self.delay)
         files = list(self.log_dir.glob("*.log"))
         msg = f"files for checking logs = {files}"
         logger.warning(msg)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -185,6 +185,7 @@ def alien_egg(head, left, right, random_state=None):
 
     winner = 0 if ldiff < rdiff else 1
     random_state = check_random_state(random_state)
+
     if random_state.uniform() <= p_correct:
         return winner
     return 1 - winner

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,13 +76,15 @@ class Server:
 
 def _clear_logs(log=None):
     if log:
-        log.write_text("")
+        with log.open(mode="w") as f:
+            print("", file=f)
     else:
         this_dir = Path(__file__).absolute().parent
         root_dir = this_dir.parent
         log_dir = root_dir / "out"
         for log in log_dir.glob("*.log"):
-            log.write_text("")
+            _clear_logs(log=log)
+        sleep(5)
 
 
 @pytest.fixture()
@@ -98,6 +100,8 @@ def server():
     if dump.exists():
         dump.unlink()
     server.reset()
+    _clear_logs()
+    _clear_logs()
 
 
 class LogError(Exception):


### PR DESCRIPTION
**What does this PR implement?**
It changes the defaults for Salmon.

* API: the values change, and there's also some easier methods to pass arguments to every sampler.
    * API: allow customizing the HTML title of query page
    * API: renames `alg_ident` to `sampler`.
* DOC: the documentation around the defaults is much better.
* DOC MAINT: including...
    * also adds to "why adaptive?"
    * cleans up docs around init file structure
    * clarifies samplers with same name.
    * expands upon examples (shows/tests default config, shows customization, etc)
* TST: the config are tested too!
* TST BUG: fixes CI testing! (required some backend work to make sure old endpoints weren't being hit after being deleted).
    * MAINT: properly sets number of processors
* API: now YAML in `/config` can be uploaded to `/init`.
    * (technically some backwards incompatibility; `n` has been removed from `/config`).
* TST: makes sure configs are proper experiments.
* MAINT: only change docs on release (lesson learned)
* MAINT/DOC: cleans up Runner/Sampler

**Reference issues/PRs**
Closes #124, closes #82 and closes #115.