### PR TITLE
find all packages but exclude tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
+from setuptools import find_packages
 from os.path import exists
 from glob import glob
 
@@ -10,13 +11,8 @@ import versioneer
 with open("./requirements.txt", "r") as f:
     install_requires = [r for r in f.read().split("\n") if r]
 
-packages = [
-    "salmon",
-    "salmon.frontend",
-    "salmon.backend",
-    "salmon.triplets",
-    "salmon._out",
-]
+packages = find_packages(where='.', exclude=['tests'])
+
 
 long_description = """Salmon is a tool for efficiently generating ordinal
 embeddings. It relies on "active" machine learning algorithms to choose the


### PR DESCRIPTION
### Issue
After using pip to install the salmon-triplets package, the following import statement fails: `from salmon.triplets.offline import OfflineEmbedding`. There are actually two ways it fails:
First, a required directory does not exist:
```
RuntimeError: Directory '/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/frontend/static' does not exist
```
If that issue is then "fixed" by creating the directory, then the import still fails:
```
ImportError: cannot import name 'samplers' from 'salmon.triplets'
```
### Steps to Reproduce

1. Create a new virtual environment and install salmon-triplets:
```
python3 -m venv .venv
source .venv/bin/activate
pip install salmon-triplets
```
2. Execute the import statement:
```
>>> from salmon.triplets.offline import OfflineEmbedding
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/__init__.py", line 2, in <module>
    from salmon.backend import app as app_algs
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/backend/__init__.py", line 1, in <module>
    from salmon.backend.core import app
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/backend/core.py", line 17, in <module>
    from salmon.frontend.utils import ServerException
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/frontend/__init__.py", line 1, in <module>
    from salmon.frontend.private import *
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/frontend/private.py", line 35, in <module>
    from salmon.frontend.public import _ensure_initialized, app, templates
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/frontend/public.py", line 64, in <module>
    app.mount("/static", StaticFiles(directory=str(pkg_dir / "static")), name="static")
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/starlette/staticfiles.py", line 55, in __init__
    raise RuntimeError(f"Directory '{directory}' does not exist")
RuntimeError: Directory '/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/frontend/static' does not exist
```
3. Fix the initial error with a `mkdir /Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/frontend/static`
4. Attempt the import again:
```
>>> from salmon.triplets.offline import OfflineEmbedding
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/__init__.py", line 2, in <module>
    from salmon.backend import app as app_algs
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/backend/__init__.py", line 1, in <module>
    from salmon.backend.core import app
  File "/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/backend/core.py", line 18, in <module>
    from salmon.triplets import samplers
ImportError: cannot import name 'samplers' from 'salmon.triplets' (/Users/jsicotte/temp/.venv/lib/python3.9/site-packages/salmon/triplets/__init__.py)
``` 

### Fix
The current package specification in the `setup.py` does not recursively find packages. However, this issue does not seem to appear when one does a `pip install -e .`. To include the sub-packages the `find_packages` function was used.
After building the wheel (`python setup.py bdist_wheel`), I verified that it did contain the modules under `salmon.triplets`. I then manually installed the wheel file in a fresh virtual environment and verified that the import worked without issue.
